### PR TITLE
🚧 Partial implementation of the `pageAction` api

### DIFF
--- a/.config/webpack.config.js
+++ b/.config/webpack.config.js
@@ -154,7 +154,7 @@ const sharedSettings = (contentFiles, dev) => {
       }),
       new WebpackLicensePlugin({
         licenseOverrides: {
-          'remixicon@3.5.0': 'Apache-2.0',
+          'remixicon@3.7.0': 'Apache-2.0',
         },
 
         includePackages: () =>

--- a/docs/webext/background.md
+++ b/docs/webext/background.md
@@ -1,0 +1,5 @@
+# Background pages
+
+## Differences
+
+- Non-persistent background pages will not restart

--- a/docs/webext/pageAction.md
+++ b/docs/webext/pageAction.md
@@ -1,0 +1,5 @@
+# PageActions
+
+## Differences
+
+- `onClicked`: The first argument is the click info, not the `Tab` info

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.8.1",
     "eslint": "^8.53.0",
+    "eslint-plugin-listeners": "^1.4.0",
     "execa": "^8.0.1",
     "gecko-types": "github:quark-platform/gecko-types",
     "html-webpack-plugin": "^5.5.3",
@@ -123,7 +124,8 @@
       "sourceType": "module"
     },
     "plugins": [
-      "@typescript-eslint"
+      "@typescript-eslint",
+      "listeners"
     ],
     "rules": {
       "@typescript-eslint/triple-slash-reference": "off",

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "prettier-plugin-organize-imports": "^3.2.3",
     "prettier-plugin-svelte": "^3.0.3",
     "style-loader": "^3.3.3",
-    "svelte": "^4.2.1",
+    "svelte": "^4.2.8",
     "svelte-loader": "^3.1.9",
-    "svelte-preprocess": "^5.0.4",
+    "svelte-preprocess": "^5.1.2",
     "svelte-sequential-preprocessor": "^2.0.1",
     "ts-loader": "^9.5.0",
     "typescript": "^5.2.2",
@@ -78,7 +78,7 @@
   },
   "pnpm": {
     "patchedDependencies": {
-      "svelte@4.2.1": "patches/svelte@4.2.1.patch",
+      "svelte@4.2.8": "patches/svelte@4.2.1.patch",
       "webpack-license-plugin@4.4.2": "patches/webpack-license-plugin@4.4.2.patch",
       "@melt-ui/svelte@0.64.5": "patches/@melt-ui__svelte@0.64.5.patch"
     }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "fnts": "^2.0.1",
     "mitt": "^3.0.1",
     "nanoid": "^5.0.3",
-    "remixicon": "^3.5.0",
+    "remixicon": "^3.7.0",
     "snarkdown": "^2.0.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ devDependencies:
     version: 8.0.1
   gecko-types:
     specifier: github:quark-platform/gecko-types
-    version: github.com/quark-platform/gecko-types/98eca1c9a0ca382b5acfcc956a3934aa3dd08557
+    version: github.com/quark-platform/gecko-types/e4efe38ce26c3617d7a3ecb13491bca2004e0377
   html-webpack-plugin:
     specifier: ^5.5.3
     version: 5.5.3(webpack@5.89.0)
@@ -4566,8 +4566,8 @@ packages:
     resolution: {integrity: sha512-FSZOvfJVfMWhk/poictNsDBCXq/Z+2Zu2peWs6d8OhWWb9nY++czw95D47hdw06L/kfjasLevwrbUtnXyWLAJw==}
     dev: true
 
-  github.com/quark-platform/gecko-types/98eca1c9a0ca382b5acfcc956a3934aa3dd08557:
-    resolution: {tarball: https://codeload.github.com/quark-platform/gecko-types/tar.gz/98eca1c9a0ca382b5acfcc956a3934aa3dd08557}
+  github.com/quark-platform/gecko-types/e4efe38ce26c3617d7a3ecb13491bca2004e0377:
+    resolution: {tarball: https://codeload.github.com/quark-platform/gecko-types/tar.gz/e4efe38ce26c3617d7a3ecb13491bca2004e0377}
     name: gecko-types
     version: 1.0.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ dependencies:
     specifier: ^5.0.3
     version: 5.0.3
   remixicon:
-    specifier: ^3.5.0
-    version: 3.5.0
+    specifier: ^3.7.0
+    version: 3.7.0
   snarkdown:
     specifier: ^2.0.0
     version: 2.0.0
@@ -3489,8 +3489,8 @@ packages:
     engines: {node: '>= 0.10'}
     dev: true
 
-  /remixicon@3.5.0:
-    resolution: {integrity: sha512-wNzWGKf4frb3tEmgvP5shry0n1OdTjjEk9RHLuRuAhfA50bvEdpKH1XWNUYrHUSjAQQkkdyIm+lf4mOuysIKTQ==}
+  /remixicon@3.7.0:
+    resolution: {integrity: sha512-FFbVLRCaTtsSDe/l9JX+lT/zzm9V3kYbda25lzsy3ML5FHv/bGVKiHwZSlCo/IMhBD1/CK6SGIruyfiq4bbsuQ==}
     dev: false
 
   /renderkid@3.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ patchedDependencies:
   '@melt-ui/svelte@0.64.5':
     hash: aeypykqddydgtdgxoo44wxfeey
     path: patches/@melt-ui__svelte@0.64.5.patch
-  svelte@4.2.1:
+  svelte@4.2.8:
     hash: cm43hmf4gczhssi3isoosy53r4
     path: patches/svelte@4.2.1.patch
   webpack-license-plugin@4.4.2:
@@ -38,10 +38,10 @@ dependencies:
 devDependencies:
   '@melt-ui/pp':
     specifier: ^0.1.4
-    version: 0.1.4(@melt-ui/svelte@0.64.5)(svelte@4.2.1)
+    version: 0.1.4(@melt-ui/svelte@0.64.5)(svelte@4.2.8)
   '@melt-ui/svelte':
     specifier: ^0.64.0
-    version: 0.64.5(patch_hash=aeypykqddydgtdgxoo44wxfeey)(svelte@4.2.1)
+    version: 0.64.5(patch_hash=aeypykqddydgtdgxoo44wxfeey)(svelte@4.2.8)
   '@tinyhttp/app':
     specifier: ^2.2.1
     version: 2.2.1
@@ -107,19 +107,19 @@ devDependencies:
     version: 3.2.3(prettier@3.0.3)(typescript@5.2.2)
   prettier-plugin-svelte:
     specifier: ^3.0.3
-    version: 3.0.3(prettier@3.0.3)(svelte@4.2.1)
+    version: 3.0.3(prettier@3.0.3)(svelte@4.2.8)
   style-loader:
     specifier: ^3.3.3
     version: 3.3.3(webpack@5.89.0)
   svelte:
-    specifier: ^4.2.1
-    version: 4.2.1(patch_hash=cm43hmf4gczhssi3isoosy53r4)
+    specifier: ^4.2.8
+    version: 4.2.8(patch_hash=cm43hmf4gczhssi3isoosy53r4)
   svelte-loader:
     specifier: ^3.1.9
-    version: 3.1.9(svelte@4.2.1)
+    version: 3.1.9(svelte@4.2.8)
   svelte-preprocess:
-    specifier: ^5.0.4
-    version: 5.0.4(postcss@8.4.31)(svelte@4.2.1)(typescript@5.2.2)
+    specifier: ^5.1.2
+    version: 5.1.2(postcss@8.4.31)(svelte@4.2.8)(typescript@5.2.2)
   svelte-sequential-preprocessor:
     specifier: ^2.0.1
     version: 2.0.1
@@ -425,19 +425,19 @@ packages:
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
     dev: true
 
-  /@melt-ui/pp@0.1.4(@melt-ui/svelte@0.64.5)(svelte@4.2.1):
+  /@melt-ui/pp@0.1.4(@melt-ui/svelte@0.64.5)(svelte@4.2.8):
     resolution: {integrity: sha512-zR+Kl3CZJPJBHW8V7YcdQCMI/dVcnW9Ct3yGbVaIywYVStVRS7F9uEDOea3xLLT2WTGodQePzPlUn53yKFu87g==}
     engines: {pnpm: '>=8.6.3'}
     peerDependencies:
       '@melt-ui/svelte': '>= 0.29.0'
       svelte: ^3.55.0 || ^4.0.0 || ^5.0.0-next.1
     dependencies:
-      '@melt-ui/svelte': 0.64.5(patch_hash=aeypykqddydgtdgxoo44wxfeey)(svelte@4.2.1)
+      '@melt-ui/svelte': 0.64.5(patch_hash=aeypykqddydgtdgxoo44wxfeey)(svelte@4.2.8)
       estree-walker: 3.0.3
-      svelte: 4.2.1(patch_hash=cm43hmf4gczhssi3isoosy53r4)
+      svelte: 4.2.8(patch_hash=cm43hmf4gczhssi3isoosy53r4)
     dev: true
 
-  /@melt-ui/svelte@0.64.5(patch_hash=aeypykqddydgtdgxoo44wxfeey)(svelte@4.2.1):
+  /@melt-ui/svelte@0.64.5(patch_hash=aeypykqddydgtdgxoo44wxfeey)(svelte@4.2.8):
     resolution: {integrity: sha512-nPQA2guLuLitpZ6A968eWyGMC2riTKLq4R26hPRLdzP/JHCpd9yvddgMwil8JKbUKjT2dC3i358vUqeUOGxknA==}
     peerDependencies:
       svelte: '>=3 <5'
@@ -448,7 +448,7 @@ packages:
       dequal: 2.0.3
       focus-trap: 7.5.4
       nanoid: 4.0.2
-      svelte: 4.2.1(patch_hash=cm43hmf4gczhssi3isoosy53r4)
+      svelte: 4.2.8(patch_hash=cm43hmf4gczhssi3isoosy53r4)
     dev: true
     patched: true
 
@@ -3368,14 +3368,14 @@ packages:
       typescript: 5.2.2
     dev: true
 
-  /prettier-plugin-svelte@3.0.3(prettier@3.0.3)(svelte@4.2.1):
+  /prettier-plugin-svelte@3.0.3(prettier@3.0.3)(svelte@4.2.8):
     resolution: {integrity: sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
       prettier: 3.0.3
-      svelte: 4.2.1(patch_hash=cm43hmf4gczhssi3isoosy53r4)
+      svelte: 4.2.8(patch_hash=cm43hmf4gczhssi3isoosy53r4)
     dev: true
 
   /prettier@3.0.3:
@@ -3968,28 +3968,28 @@ packages:
     resolution: {integrity: sha512-oU+Xv7Dl4kRU2kdFjsoPLfJfnt5hUhsFUZtuzI3Ku/f2iAFZqBoEuXOqK3N9ngD4dxQOmN4OKWPHVi3NeAeAfQ==}
     dev: true
 
-  /svelte-hmr@0.14.12(svelte@4.2.1):
+  /svelte-hmr@0.14.12(svelte@4.2.8):
     resolution: {integrity: sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'
     dependencies:
-      svelte: 4.2.1(patch_hash=cm43hmf4gczhssi3isoosy53r4)
+      svelte: 4.2.8(patch_hash=cm43hmf4gczhssi3isoosy53r4)
     dev: true
 
-  /svelte-loader@3.1.9(svelte@4.2.1):
+  /svelte-loader@3.1.9(svelte@4.2.8):
     resolution: {integrity: sha512-RITPqze3TppOhaZF8SEFTDTwFHov17k3UkOjpxyL/No/YVrvckKmXWOEj7QEpsZZZSNQPb28tMZbHEI2xLhJMQ==}
     peerDependencies:
       svelte: ^3.0.0 || ^4.0.0-next.0
     dependencies:
       loader-utils: 2.0.4
-      svelte: 4.2.1(patch_hash=cm43hmf4gczhssi3isoosy53r4)
+      svelte: 4.2.8(patch_hash=cm43hmf4gczhssi3isoosy53r4)
       svelte-dev-helper: 1.1.9
-      svelte-hmr: 0.14.12(svelte@4.2.1)
+      svelte-hmr: 0.14.12(svelte@4.2.8)
     dev: true
 
-  /svelte-preprocess@5.0.4(postcss@8.4.31)(svelte@4.2.1)(typescript@5.2.2):
-    resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
+  /svelte-preprocess@5.1.2(postcss@8.4.31)(svelte@4.2.8)(typescript@5.2.2):
+    resolution: {integrity: sha512-XF0aliMAcYnP4hLETvB6HRAMnaL09ASYT1Z2I1Gwu0nz6xbdg/dSgAEthtFZJA4AKrNhFDFdmUDO+H9d/6xg5g==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
     peerDependencies:
@@ -3997,12 +3997,12 @@ packages:
       coffeescript: ^2.5.1
       less: ^3.11.3 || ^4.0.0
       postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
       pug: ^3.0.0
       sass: ^1.26.8
       stylus: ^0.55.0
       sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0
+      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
       typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
     peerDependenciesMeta:
       '@babel/core':
@@ -4032,7 +4032,7 @@ packages:
       postcss: 8.4.31
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 4.2.1(patch_hash=cm43hmf4gczhssi3isoosy53r4)
+      svelte: 4.2.8(patch_hash=cm43hmf4gczhssi3isoosy53r4)
       typescript: 5.2.2
     dev: true
 
@@ -4040,12 +4040,12 @@ packages:
     resolution: {integrity: sha512-N5JqlBni6BzElxmuFrOPxOJnjsxh1cFDACLEVKs8OHBcx8ZNRO1p5SxuQex1m3qbLzAC8G99EHeWcxGkjyKjLQ==}
     engines: {node: '>=16'}
     dependencies:
-      svelte: 4.2.1(patch_hash=cm43hmf4gczhssi3isoosy53r4)
+      svelte: 4.2.8(patch_hash=cm43hmf4gczhssi3isoosy53r4)
       tslib: 2.6.2
     dev: true
 
-  /svelte@4.2.1(patch_hash=cm43hmf4gczhssi3isoosy53r4):
-    resolution: {integrity: sha512-LpLqY2Jr7cRxkrTc796/AaaoMLF/1ax7cto8Ot76wrvKQhrPmZ0JgajiWPmg9mTSDqO16SSLiD17r9MsvAPTmw==}
+  /svelte@4.2.8(patch_hash=cm43hmf4gczhssi3isoosy53r4):
+    resolution: {integrity: sha512-hU6dh1MPl8gh6klQZwK/n73GiAHiR95IkFsesLPbMeEZi36ydaXL/ZAb4g9sayT0MXzpxyZjR28yderJHxcmYA==}
     engines: {node: '>=16'}
     dependencies:
       '@ampproject/remapping': 2.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ devDependencies:
   eslint:
     specifier: ^8.53.0
     version: 8.53.0
+  eslint-plugin-listeners:
+    specifier: ^1.4.0
+    version: 1.4.0(eslint@8.53.0)
   execa:
     specifier: ^8.0.1
     version: 8.0.1
@@ -1845,6 +1848,15 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /eslint-plugin-listeners@1.4.0(eslint@8.53.0):
+    resolution: {integrity: sha512-18zHHjVDeE/AD5UFNQdGI9nWxhnER8OYbgqX9Sfe4tNvHpX4AL5ICwCWDo3i/31l4KAPIT8v8KY1Rl+3POZNDg==}
+    engines: {node: '>=8.10.0'}
+    peerDependencies:
+      eslint: '>=0.8.0'
+    dependencies:
+      eslint: 8.53.0
     dev: true
 
   /eslint-scope@5.1.1:

--- a/scripts/lib/files.ts
+++ b/scripts/lib/files.ts
@@ -15,8 +15,10 @@ export const CHANGES: { file: string; append?: string | string[] }[] = [
   },
   {
     file: 'components/components.manifest',
-    append:
+    append: [
       'category webextension-modules browser chrome://browser/content/extensions/ext-browser.json',
+      'category webextension-scripts c-browser chrome://browser/content/extensions/parent/ext-browser.js',
+    ],
   },
 ]
 

--- a/scripts/lib/files.ts
+++ b/scripts/lib/files.ts
@@ -8,8 +8,15 @@ import { getArtifactFile } from './constants.js'
 export const CHANGES: { file: string; append?: string | string[] }[] = [
   {
     file: 'chrome/chrome.manifest',
-    append:
+    append: [
+      'locale branding en-US en-US/locale/branding/',
       'resource search-extensions browser/content/browser/search-extensions/ contentaccessible=yes',
+    ],
+  },
+  {
+    file: 'components/components.manifest',
+    append:
+      'category webextension-modules browser chrome://browser/content/extensions/ext-browser.json',
   },
 ]
 

--- a/scripts/lib/license.ts
+++ b/scripts/lib/license.ts
@@ -11,7 +11,7 @@ const MPL_HEADER = [
 
 const FIXES = [
   {
-    regex: new RegExp('.*\\.(css|((j|t)s))'),
+    regex: new RegExp('.*\\.(css|(m?(j|t)s))'),
     commentOpen: '/* ',
     comment: ' * ',
     commentClose: ' */\n',
@@ -21,6 +21,10 @@ const FIXES = [
     commentOpen: '<!-- ',
     comment: '   - ',
     commentClose: ' -->\n',
+  },
+  {
+    regex: new RegExp('.*\\.(py|ftl)'),
+    comment: '# ',
   },
 ]
 

--- a/scripts/lib/linker.ts
+++ b/scripts/lib/linker.ts
@@ -29,7 +29,11 @@ export async function linkTscFolder(folderName: string) {
   }
 }
 
-export async function linkStaticFolder(folderName: string) {
+export async function linkStaticFolder(
+  folderName: string,
+  outFolderName?: string,
+  ext = '.sys.mjs',
+) {
   const linkFile = await readFile(
     getStaticFile(`${folderName}/link.json`),
     'utf-8',
@@ -37,13 +41,26 @@ export async function linkStaticFolder(folderName: string) {
   const links = JSON.parse(linkFile) as string[]
 
   for (const link of links) {
-    const fileName = `${link}.sys.mjs`
-    const geckoPath = getArtifactFile(`${folderName}/${fileName}`)
+    const fileName = `${link}${ext}`
+    const geckoPath = getArtifactFile(
+      `${outFolderName || folderName}/${fileName}`,
+    )
     const srcFile = getStaticFile(`${folderName}/${fileName}`)
 
     if (existsSync(geckoPath)) await rm(geckoPath)
-    if (!existsSync(dirname(srcFile)))
+    if (!existsSync(dirname(geckoPath)))
       await mkdir(dirname(geckoPath), { recursive: true })
-    await symlink(getStaticFile(`${folderName}/${fileName}`), geckoPath)
+    await symlink(srcFile, geckoPath)
   }
+}
+
+export async function linkFolder(staticName: string, outputName: string) {
+  const staticFolder = getStaticFile(staticName)
+  const geckoFolder = getArtifactFile(outputName)
+
+  if (existsSync(geckoFolder)) await rm(geckoFolder, { recursive: true })
+  if (!existsSync(dirname(geckoFolder)))
+    await mkdir(dirname(geckoFolder), { recursive: true })
+
+  await symlink(staticFolder, geckoFolder)
 }

--- a/scripts/license-check.ts
+++ b/scripts/license-check.ts
@@ -4,7 +4,7 @@
 import { readFileSync } from 'node:fs'
 import { argv } from 'node:process'
 
-import { SCRIPTS_PATH, SRC_PATH } from './lib/constants.js'
+import { SCRIPTS_PATH, SRC_PATH, STATIC_PATH } from './lib/constants.js'
 import { walkDirectory } from './lib/fs.js'
 import { autoFix, isValidLicense } from './lib/license.js'
 import { failure } from './lib/logging.js'
@@ -17,6 +17,7 @@ const shouldFix = argv.includes('--fix')
 const filesToCheck = [
   ...(await walkDirectory(SCRIPTS_PATH)),
   ...(await walkDirectory(SRC_PATH)),
+  ...(await walkDirectory(STATIC_PATH)),
 ]
 
 const invalidFiles = filesToCheck

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -21,7 +21,7 @@ import {
   getSrcFile,
 } from './lib/constants.js'
 import { setupFiles } from './lib/files.js'
-import { linkStaticFolder, linkTscFolder } from './lib/linker.js'
+import { linkFolder, linkStaticFolder, linkTscFolder } from './lib/linker.js'
 import { failure, info } from './lib/logging.js'
 import { downloadReleaseAsset, getLatestRelease } from './lib/releases.js'
 
@@ -86,6 +86,9 @@ await linkTscFolder('actors')
 
 // Link static folders
 await linkStaticFolder('modules')
+await linkStaticFolder('localization', undefined, '')
+await linkStaticFolder('chrome', undefined, '')
+// await linkFolder('extensions', 'chrome/browser/content/browser/extensions')
 
 info('Setting up files...')
 await setupFiles()

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -21,7 +21,7 @@ import {
   getSrcFile,
 } from './lib/constants.js'
 import { setupFiles } from './lib/files.js'
-import { linkFolder, linkStaticFolder, linkTscFolder } from './lib/linker.js'
+import { linkStaticFolder, linkTscFolder } from './lib/linker.js'
 import { failure, info } from './lib/logging.js'
 import { downloadReleaseAsset, getLatestRelease } from './lib/releases.js'
 

--- a/src/actors/LinkHandlerParent.ts
+++ b/src/actors/LinkHandlerParent.ts
@@ -10,7 +10,7 @@ export class LinkHandlerParent extends JSWindowActorParent {
 
     switch (aMsg.name) {
       case 'Link:SetIcon':
-        return win.windowApi.setIcon(
+        return win.windowApi.tabs.setIcon(
           this.browsingContext.embedderElement,
           aMsg.data.iconURL,
         )

--- a/src/content/browser/Browser.svelte
+++ b/src/content/browser/Browser.svelte
@@ -8,10 +8,10 @@
   import CustomizableUi from './components/customizableUI/CustomizableUI.svelte'
   import { BrowserContextMenu, HamburgerMenu } from './components/menus'
   import Keybindings from './components/keybindings/Keybindings.svelte'
-  import { tabs, selectedTab } from './lib/window/tabs'
+  import { tabs, selectedTabId } from './lib/window/tabs'
 
   let component = customizableUIDynamicPref('browser.uiCustomization.state')
-  $: currentTab = $tabs.find((tab) => tab.getId() == $selectedTab)
+  $: currentTab = $tabs.find((tab) => tab.getId() == $selectedTabId)
 </script>
 
 {#if currentTab}

--- a/src/content/browser/components/customizableUI/BrowserView.svelte
+++ b/src/content/browser/components/customizableUI/BrowserView.svelte
@@ -10,7 +10,7 @@
   } from '@shared/customizableUI'
   import UiItemBase from './UIItemBase.svelte'
   import Browser from '../Browser.svelte'
-  import { selectedTab, tabs } from '@browser/lib/window/tabs'
+  import { selectedTabId, tabs } from '@browser/lib/window/tabs'
 
   export let component: ComponentId & BrowserComponent
   export let root: Component
@@ -24,6 +24,6 @@
 
 <UiItemBase {component} {root}>
   {#each sortedBrowers as tab (tab.getId())}
-    <Browser {tab} selectedTab={$selectedTab} />
+    <Browser {tab} selectedTab={$selectedTabId} />
   {/each}
 </UiItemBase>

--- a/src/content/browser/components/customizableUI/Tabs.svelte
+++ b/src/content/browser/components/customizableUI/Tabs.svelte
@@ -11,7 +11,7 @@
   import Tab from '@browser/components/tabs/Tab.svelte'
 
   import UiItemBase from './UIItemBase.svelte'
-  import { selectedTab, tabs } from '@browser/lib/window/tabs'
+  import { selectedTabId, tabs } from '@browser/lib/window/tabs'
 
   export let component: ComponentId & TabsComponent
   export let root: Component
@@ -19,7 +19,7 @@
 
 <UiItemBase {component} {root} class="tabs" on:drop={(e) => e.preventDefault()}>
   {#each $tabs as tab (tab.getId())}
-    <Tab {tab} bind:selectedTab={$selectedTab} />
+    <Tab {tab} bind:selectedTab={$selectedTabId} />
   {/each}
 </UiItemBase>
 

--- a/src/content/browser/components/omnibox/Omnibox.svelte
+++ b/src/content/browser/components/omnibox/Omnibox.svelte
@@ -90,7 +90,7 @@
       />
 
       {#each $pageActions as [_extId, pageAction]}
-        {#if pageAction.shouldShow($uri.asciiSpec)}
+        {#if pageAction.shouldShow($uri.asciiSpec, tab.getTabId())}
           <PageAction {pageAction} />
         {/if}
       {/each}

--- a/src/content/browser/components/omnibox/Omnibox.svelte
+++ b/src/content/browser/components/omnibox/Omnibox.svelte
@@ -90,7 +90,9 @@
       />
 
       {#each $pageActions as [_extId, pageAction]}
-        <PageAction {pageAction} />
+        {#if pageAction.shouldShow($uri.asciiSpec)}
+          <PageAction {pageAction} />
+        {/if}
       {/each}
 
       <Bookmarks {tab} />

--- a/src/content/browser/components/omnibox/Omnibox.svelte
+++ b/src/content/browser/components/omnibox/Omnibox.svelte
@@ -8,6 +8,8 @@
   import type { Tab } from '@browser/lib/window/tab'
 
   import Bookmarks from './Bookmarks.svelte'
+  import { pageActions } from '@browser/lib/modules/EPageActionsBindings'
+  import PageAction from './PageAction.svelte'
 
   const suggestionsModule = import('@shared/search/suggestions')
 
@@ -86,6 +88,10 @@
           await generateSuggestions()
         }}
       />
+
+      {#each $pageActions as [_extId, pageAction]}
+        <PageAction {pageAction} />
+      {/each}
 
       <Bookmarks {tab} />
     </div>

--- a/src/content/browser/components/omnibox/PageAction.svelte
+++ b/src/content/browser/components/omnibox/PageAction.svelte
@@ -18,6 +18,7 @@
     getIconUrlForPreferredSize,
     pageActionIcons,
   } from '@browser/lib/modules/EPageActionsBindings'
+  import { clickModifiersFromEvent } from '@shared/domUtils'
 
   export let pageAction: PageAction
   const icons = pageActionIcons(pageAction)
@@ -41,7 +42,6 @@
       browser.remove()
     }
 
-    console.log(pageAction.popupUrl)
     if (!pageAction.popupUrl) return
     const uri = resource.NetUtil.newURI(pageAction.popupUrl)
 
@@ -80,9 +80,18 @@
     setURI(lBrowser, uri)
   }
 
-  const OPEN_PANEL = async () => {
+  const handleClick = async (event: MouseEvent) => {
+    // Send the event to the extension
+    pageAction.events.emit('click', {
+      clickData: {
+        modifiers: clickModifiersFromEvent(event),
+        button: event.button,
+      },
+    })
+
     await buildPanelBrowser()
-    panel.openPopup(button, 'bottomright topright')
+    // Panel may not exist if there is no popupUrl
+    if (panel) panel.openPopup(button, 'bottomright topright')
   }
 
   onMount(() => () => {
@@ -99,7 +108,7 @@
 <ToolbarButton
   kind="page-icon"
   bind:button
-  on:click={OPEN_PANEL}
+  on:click={handleClick}
   tooltip={pageAction.tooltip}
 >
   {#if $icons}

--- a/src/content/browser/components/omnibox/PageAction.svelte
+++ b/src/content/browser/components/omnibox/PageAction.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { PageAction } from 'resource://app/modules/EPageActions.sys.mjs'
+  import ToolbarButton from '@shared/components/ToolbarButton.svelte'
+
+  export let pageAction: PageAction
+</script>
+
+<ToolbarButton kind="page-icon">
+  <i class="ri-puzzle-line"></i>
+</ToolbarButton>

--- a/src/content/browser/components/omnibox/PageAction.svelte
+++ b/src/content/browser/components/omnibox/PageAction.svelte
@@ -14,8 +14,13 @@
   import { spinLock } from '@browser/lib/spinlock'
   import { MessageReviver } from '@shared/xul/messageReciver'
   import { onMount } from 'svelte'
+  import {
+    getIconUrlForPreferredSize,
+    pageActionIcons,
+  } from '@browser/lib/modules/EPageActionsBindings'
 
   export let pageAction: PageAction
+  const icons = pageActionIcons(pageAction)
 
   let panel: any
   let browser: XULBrowserElement
@@ -97,7 +102,15 @@
   on:click={OPEN_PANEL}
   tooltip={pageAction.tooltip}
 >
-  <i class="ri-puzzle-line"></i>
+  {#if $icons}
+    <img
+      src={getIconUrlForPreferredSize($icons, 16)}
+      alt="Page action icon"
+      class="icon"
+    />
+  {:else}
+    <i class="ri-puzzle-line icon"></i>
+  {/if}
 </ToolbarButton>
 
 {#if pageAction.popupUrl}
@@ -109,5 +122,12 @@
     --panel-shadow-margin: 0;
     --panel-padding: 0;
     --panel-border-radius: 0.5rem;
+  }
+
+  .icon {
+    width: 1em;
+    height: 1em;
+
+    color: var(--text);
   }
 </style>

--- a/src/content/browser/components/omnibox/PageAction.svelte
+++ b/src/content/browser/components/omnibox/PageAction.svelte
@@ -5,10 +5,108 @@
 <script lang="ts">
   import type { PageAction } from 'resource://app/modules/EPageActions.sys.mjs'
   import ToolbarButton from '@shared/components/ToolbarButton.svelte'
+  import {
+    createBrowser,
+    getBrowserRemoteType,
+    setURI,
+  } from '@browser/lib/xul/browser'
+  import { resource } from '@browser/lib/resources'
+  import { spinLock } from '@browser/lib/spinlock'
+  import { MessageReviver } from '@shared/xul/messageReciver'
+  import { onMount } from 'svelte'
 
   export let pageAction: PageAction
+
+  let panel: any
+  let browser: XULBrowserElement
+  let button: HTMLButtonElement
+
+  const messageReceiver = new MessageReviver(({ name, data }) => {
+    switch (name) {
+      case 'Extension:BrowserResized':
+        const { width, height } = data as { height: number; width: number }
+        browser.style.width = `${width}px`
+        browser.style.height = `${height}px`
+        break
+    }
+  })
+
+  async function buildPanelBrowser() {
+    if (browser) {
+      browser.remove()
+    }
+
+    console.log(pageAction.popupUrl)
+    if (!pageAction.popupUrl) return
+    const uri = resource.NetUtil.newURI(pageAction.popupUrl)
+
+    const lBrowser = createBrowser({
+      remoteType: getBrowserRemoteType(uri),
+      attributes: {
+        disableglobalhistory: 'true',
+        messagemanagergroup: 'todo',
+        'webextension-view-type': 'popup',
+      },
+    })
+
+    lBrowser.addEventListener('DidChangeBrowserRemoteness', () =>
+      console.log('ChangeRemoteness'),
+    )
+
+    await spinLock(() => panel)
+    panel.appendChild(lBrowser)
+    browser = lBrowser
+
+    lBrowser.messageManager.addMessageListener(
+      'Extension:BrowserResized',
+      messageReceiver,
+    )
+
+    lBrowser.messageManager.loadFrameScript(
+      'chrome://extensions/content/ext-browser-content.js',
+      false,
+      true,
+    )
+
+    lBrowser.messageManager.sendAsyncMessage('Extension:InitBrowser', {
+      allowScriptsToClose: true,
+      maxWidth: 800,
+      maxHeight: 600,
+    })
+    lBrowser.style.borderRadius = 'inherit'
+
+    await spinLock(() => lBrowser.mInitialized)
+    setURI(lBrowser, uri)
+  }
+
+  const OPEN_PANEL = async () => {
+    await buildPanelBrowser()
+    panel.openPopup(button, 'bottomright topright')
+  }
+
+  onMount(() => () => {
+    if (browser) {
+      browser.messageManager.removeMessageListener(
+        'Extension:BrowserResized',
+        messageReceiver,
+      )
+      browser.remove()
+    }
+  })
 </script>
 
-<ToolbarButton kind="page-icon">
+<ToolbarButton kind="page-icon" bind:button on:click={OPEN_PANEL}>
   <i class="ri-puzzle-line"></i>
 </ToolbarButton>
+
+{#if pageAction.popupUrl}
+  <xul:panel bind:this={panel} class="popup"></xul:panel>
+{/if}
+
+<style>
+  .popup {
+    --panel-shadow-margin: 0;
+    --panel-padding: 0;
+    --panel-border-radius: 0.5rem;
+  }
+</style>

--- a/src/content/browser/components/omnibox/PageAction.svelte
+++ b/src/content/browser/components/omnibox/PageAction.svelte
@@ -49,10 +49,6 @@
       },
     })
 
-    lBrowser.addEventListener('DidChangeBrowserRemoteness', () =>
-      console.log('ChangeRemoteness'),
-    )
-
     await spinLock(() => panel)
     panel.appendChild(lBrowser)
     browser = lBrowser
@@ -95,7 +91,12 @@
   })
 </script>
 
-<ToolbarButton kind="page-icon" bind:button on:click={OPEN_PANEL}>
+<ToolbarButton
+  kind="page-icon"
+  bind:button
+  on:click={OPEN_PANEL}
+  tooltip={pageAction.tooltip}
+>
   <i class="ri-puzzle-line"></i>
 </ToolbarButton>
 

--- a/src/content/browser/components/omnibox/PageAction.svelte
+++ b/src/content/browser/components/omnibox/PageAction.svelte
@@ -1,3 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
 <script lang="ts">
   import type { PageAction } from 'resource://app/modules/EPageActions.sys.mjs'
   import ToolbarButton from '@shared/components/ToolbarButton.svelte'

--- a/src/content/browser/components/tabs/tabDrag.ts
+++ b/src/content/browser/components/tabs/tabDrag.ts
@@ -17,6 +17,8 @@ import {
 } from '@browser/lib/window/tabs'
 import { getWindowById } from '@browser/lib/window/window'
 
+/* eslint listeners/no-missing-remove-event-listener: 'error' */
+
 export const TAB_DATA_TYPE = 'experiment/tab'
 
 const dragOver = (
@@ -121,8 +123,6 @@ const drop = async (event: DragEvent) => {
 
 const dragEnd = (tabToMove: Tab) => async (event: DragEvent) => {
   if (event.dataTransfer?.dropEffect != 'none') return
-
-  console.log('dropped outside of window!')
 
   // The next window that is created is going to be for the new tab
   const newWindowPromise = waitForEvent(

--- a/src/content/browser/lib/modules/EPageActionsBindings.ts
+++ b/src/content/browser/lib/modules/EPageActionsBindings.ts
@@ -1,0 +1,15 @@
+import { readable } from 'svelte/store'
+
+import { resource } from '../resources'
+
+/**
+ * @todo lazy loading store
+ */
+export const pageActions = readable(
+  resource.EPageActions.pageActions.entries(),
+  (set) => {
+    const update = () => set(resource.EPageActions.pageActions.entries())
+    resource.EPageActions.events.on('*', update)
+    return () => resource.EPageActions.events.off('*', update)
+  },
+)

--- a/src/content/browser/lib/modules/EPageActionsBindings.ts
+++ b/src/content/browser/lib/modules/EPageActionsBindings.ts
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { readable } from 'svelte/store'
 
 import { resource } from '../resources'
@@ -6,9 +9,9 @@ import { resource } from '../resources'
  * @todo lazy loading store
  */
 export const pageActions = readable(
-  resource.EPageActions.pageActions.entries(),
+  [...resource.EPageActions.pageActions.entries()],
   (set) => {
-    const update = () => set(resource.EPageActions.pageActions.entries())
+    const update = () => set([...resource.EPageActions.pageActions.entries()])
     resource.EPageActions.events.on('*', update)
     return () => resource.EPageActions.events.off('*', update)
   },

--- a/src/content/browser/lib/modules/EPageActionsBindings.ts
+++ b/src/content/browser/lib/modules/EPageActionsBindings.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { readable } from 'svelte/store'
 
+import type { PageAction } from 'resource://app/modules/EPageActions.sys.mjs'
+
 import { resource } from '../resources'
 
 /**
@@ -16,3 +18,29 @@ export const pageActions = readable(
     return () => resource.EPageActions.events.off('*', update)
   },
 )
+
+export const pageActionIcons = (pageAction: PageAction) =>
+  readable<Record<number, string> | undefined>(pageAction.icons, (set) =>
+    pageAction.events.on('updateIcon', set),
+  )
+
+export function getIconUrlForPreferredSize(
+  icon: Record<number, string>,
+  preferredSize: number,
+) {
+  let bestSize
+
+  if (icon[preferredSize]) {
+    bestSize = preferredSize
+  } else if (icon[preferredSize * 2]) {
+    bestSize = preferredSize * 2
+  } else {
+    const sizes = Object.keys(icon)
+      .map((key) => parseInt(key, 10))
+      .sort((a, b) => a - b)
+    bestSize =
+      sizes.find((candidate) => candidate > preferredSize) || sizes.pop()!
+  }
+
+  return icon[bestSize]
+}

--- a/src/content/browser/lib/resources.ts
+++ b/src/content/browser/lib/resources.ts
@@ -7,6 +7,7 @@ import { lazyESModuleGetters } from '../../shared/TypedImportUtilities'
 
 export const resource = lazyESModuleGetters({
   E10SUtils: 'resource://gre/modules/E10SUtils.sys.mjs',
+  EPageActions: 'resource://app/modules/EPageActions.sys.mjs',
   NetUtil: 'resource://gre/modules/NetUtil.sys.mjs',
   PageThumbs: 'resource://gre/modules/PageThumbs.sys.mjs',
   WindowTracker: 'resource://app/modules/BrowserWindowTracker.sys.mjs',

--- a/src/content/browser/lib/window/api.ts
+++ b/src/content/browser/lib/window/api.ts
@@ -11,13 +11,14 @@ import {
 } from './contextMenu'
 import {
   closeTab,
+  getCurrentTab,
   getTabById,
   openTab,
   runOnCurrentTab,
   setCurrentTab,
   tabs,
 } from './tabs'
-import { id } from './window'
+import { id, setId } from './window'
 
 export type WindowTriggers = {
   bookmarkCurrentPage: undefined
@@ -27,8 +28,16 @@ export const windowApi = {
   /**
    * Identify which window this is. This should be used for actions like tab
    * moving that go across windows
+   *
+   * Note: You need to wait for the window watcher to register this window
+   * before you get a valid id
    */
   id,
+
+  /**
+   * Sets the window ID. You should only use this if you are the WindowWatcher
+   */
+  setId,
 
   windowTriggers: mitt<WindowTriggers>(),
   window: {
@@ -50,6 +59,7 @@ export const windowApi = {
     openTab,
     runOnCurrentTab,
     setCurrentTab,
+    getCurrentTab,
     getTabById,
     get tabs() {
       return tabs.readOnce()

--- a/src/content/browser/lib/window/initialize.ts
+++ b/src/content/browser/lib/window/initialize.ts
@@ -1,11 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { TAB_DATA_TYPE } from '@browser/components/tabs/tabDrag'
-
 import { resource } from '../resources'
 import { type WindowArguments, getFullWindowConfiguration } from './arguments'
 import { openTab } from './tabs'
+import {
+  initializeWindowDragOverHandler,
+  registerWithWindowTracker,
+} from './window'
 
 export function initializeWindow(args: WindowArguments | undefined) {
   // When opened via nsIWindowWatcher.openWindow, the arguments are
@@ -25,37 +27,4 @@ export function initializeWindow(args: WindowArguments | undefined) {
 
   initializeWindowDragOverHandler()
   registerWithWindowTracker()
-}
-
-/**
- * If we want to detect drops outside of the window, we need to ensure that all
- * drops **within** a browser window are handled.
- *
- * This listens for all events with a type equivalent to {@link TAB_DATA_TYPE}
- * and makes sure they have an attached drop type.
- */
-function initializeWindowDragOverHandler() {
-  const handleDragEvent = (event: DragEvent) => {
-    const rawDragRepresentation = event.dataTransfer?.getData(TAB_DATA_TYPE)
-    if (!rawDragRepresentation) return
-
-    // Set this to some drop event other than 'none' so we can detect drops
-    // outside of the window in the tab's drag handler
-    if (event.dataTransfer) event.dataTransfer.dropEffect = 'link'
-    event.preventDefault()
-  }
-
-  window.addEventListener('dragover', handleDragEvent)
-  window.addEventListener('drop', handleDragEvent)
-}
-
-/**
- * Ensures that the window tracker is aware of this window & that when it is
- * closed, the correct cleanup is performed.
- */
-function registerWithWindowTracker() {
-  resource.WindowTracker.registerWindow(window)
-  window.addEventListener('unload', () =>
-    resource.WindowTracker.removeWindow(window),
-  )
 }

--- a/src/content/browser/lib/window/tabs.ts
+++ b/src/content/browser/lib/window/tabs.ts
@@ -53,7 +53,7 @@ export function getTabById(id: number): Tab | undefined {
   return tabs.readOnce().find((tab) => tab.getId() == id)
 }
 
-function getCurrent(): Tab | undefined {
+export function getCurrentTab(): Tab | undefined {
   return getTabById(internalSelectedTab)
 }
 
@@ -63,7 +63,7 @@ export function setCurrentTab(tab: Tab) {
 }
 
 export function runOnCurrentTab<R>(method: (tab: Tab) => R): R | void {
-  const currentTab = getCurrent()
+  const currentTab = getCurrentTab()
   if (currentTab) return method(currentTab)
 }
 

--- a/src/content/browser/lib/window/tabs.ts
+++ b/src/content/browser/lib/window/tabs.ts
@@ -9,8 +9,8 @@ import { resource } from '../resources'
 import { Tab } from './tab'
 
 let internalSelectedTab = -1
-export const selectedTab = writable(-1)
-selectedTab.subscribe((v) => (internalSelectedTab = v))
+export const selectedTabId = writable(-1)
+selectedTabId.subscribe((v) => (internalSelectedTab = v))
 
 const uriPref = (pref: string) => (): nsIURIType =>
   resource.NetUtil.newURI(Services.prefs.getStringPref(pref, 'about:blank'))
@@ -22,7 +22,7 @@ export const tabs = viewableWritable<Tab[]>([])
 export function openTab(uri: nsIURIType = newTabUri()) {
   const newTab = new Tab(uri)
   tabs.update((tabs) => {
-    selectedTab.set(newTab.getId())
+    selectedTabId.set(newTab.getId())
     return [...tabs, newTab]
   })
   return newTab
@@ -39,9 +39,9 @@ export function closeTab(tab: Tab) {
     }
 
     if (filtered[tabIndex]) {
-      selectedTab.set(filtered[tabIndex].getId())
+      selectedTabId.set(filtered[tabIndex].getId())
     } else {
-      selectedTab.set(filtered[tabIndex - 1].getId())
+      selectedTabId.set(filtered[tabIndex - 1].getId())
     }
 
     tab.destroy()
@@ -78,7 +78,7 @@ export function setCurrentTabIndex(index: number) {
   if (index < 0) index = allTabs.length - 1
   if (index >= allTabs.length) index = 0
 
-  selectedTab.set(allTabs[index].getId())
+  selectedTabId.set(allTabs[index].getId())
 }
 
 export function moveTabBefore(toMoveId: number, targetId: number) {

--- a/src/content/browser/lib/window/window.ts
+++ b/src/content/browser/lib/window/window.ts
@@ -1,12 +1,47 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-import { nanoid } from 'nanoid'
+import { TAB_DATA_TYPE } from '@browser/components/tabs/tabDrag'
 
 import { resource } from '../resources'
 
-export const id = nanoid()
+export let id = -1
+export const setId = (newId: number) => (id = newId)
 
-export const getWindowById = (id: string) =>
+export const getWindowById = (id: number) =>
   resource.WindowTracker.getWindowById(id)
+
+/**
+ * If we want to detect drops outside of the window, we need to ensure that all
+ * drops **within** a browser window are handled.
+ *
+ * This listens for all events with a type equivalent to {@link TAB_DATA_TYPE}
+ * and makes sure they have an attached drop type.
+ */
+export function initializeWindowDragOverHandler() {
+  const handleDragEvent = (event: DragEvent) => {
+    const rawDragRepresentation = event.dataTransfer?.getData(TAB_DATA_TYPE)
+    if (!rawDragRepresentation) return
+
+    // Set this to some drop event other than 'none' so we can detect drops
+    // outside of the window in the tab's drag handler
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'link'
+    event.preventDefault()
+  }
+
+  window.addEventListener('dragover', handleDragEvent)
+  window.addEventListener('drop', handleDragEvent)
+}
+
+/**
+ * Ensures that the window tracker is aware of this window & that when it is
+ * closed, the correct cleanup is performed.
+ */
+export function registerWithWindowTracker() {
+  resource.WindowTracker.registerWindow(window)
+  window.addEventListener('unload', () =>
+    resource.WindowTracker.removeWindow(window),
+  )
+
+  window.addEventListener('focus', () => resource.WindowTracker.focusWindow(id))
+}

--- a/src/content/browser/lib/xul/browser.ts
+++ b/src/content/browser/lib/xul/browser.ts
@@ -39,19 +39,32 @@ export function getBrowserRemoteType(uri: nsIURIType) {
   )
 }
 
-export function createBrowser({ remoteType }: { remoteType?: string } = {}) {
+export function createBrowser({
+  remoteType,
+  attributes,
+}: {
+  remoteType?: string
+  attributes?: {
+    disableglobalhistory?: string
+    messagemanagergroup?: string
+    ['webextension-view-type']?: string
+  }
+} = {}): XULBrowserElement {
   const browser = document.createXULElement('browser')
   if (remoteType) {
     browser.setAttribute('remoteType', remoteType)
     browser.setAttribute('remote', true)
   }
 
-  for (const attribute in DEFAULT_BROWSER_ATTRIBUTES)
+  const mergedAttributes = {
+    ...DEFAULT_BROWSER_ATTRIBUTES,
+    ...(attributes || {}),
+  }
+
+  for (const attribute in mergedAttributes)
     browser.setAttribute(
       attribute,
-      DEFAULT_BROWSER_ATTRIBUTES[
-        attribute as keyof typeof DEFAULT_BROWSER_ATTRIBUTES
-      ],
+      mergedAttributes[attribute as keyof typeof mergedAttributes],
     )
 
   if (useRemoteTabs) browser.setAttribute('maychangeremoteness', 'true')

--- a/src/content/browser/lib/xul/browser.ts
+++ b/src/content/browser/lib/xul/browser.ts
@@ -22,6 +22,7 @@ export function setURI(browser: XULBrowserElement, uri: nsIURIType) {
       // remoteTypeOverride: getBrowserRemoteType(uri),
     })
   } catch (e) {
+    console.log(browser, uri)
     console.error(e)
   }
 }

--- a/src/content/shared/components/ToolbarButton.svelte
+++ b/src/content/shared/components/ToolbarButton.svelte
@@ -28,6 +28,10 @@
     border-radius: 0.5rem;
     width: 2.5rem;
     height: 2.5rem;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   .toolbar__button--page-icon {

--- a/src/content/shared/components/ToolbarButton.svelte
+++ b/src/content/shared/components/ToolbarButton.svelte
@@ -6,6 +6,7 @@
   export let disabled = false
   export let button: HTMLButtonElement | undefined = undefined
   export let kind: 'toolbar' | 'page-icon' = 'toolbar'
+  export let tooltip: string | undefined = undefined
 </script>
 
 <button
@@ -13,6 +14,7 @@
   bind:this={button}
   on:click
   {disabled}
+  title={tooltip}
 >
   <slot />
 </button>

--- a/src/content/shared/domUtils.ts
+++ b/src/content/shared/domUtils.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { lazy } from './lazy'
+
+export type ClickModifiers = 'Shift' | 'Alt' | 'Command' | 'Ctrl' | 'MacCtrl'
+export const clickModifiersFromEvent = (
+  event: MouseEvent,
+): ClickModifiers[] => {
+  const map = {
+    shiftKey: 'Shift',
+    altKey: 'Alt',
+    metaKey: 'Command',
+    ctrlKey: 'Ctrl',
+  } as const
+
+  const modifiers: ClickModifiers[] = (Object.keys(map) as (keyof typeof map)[])
+    .filter((key) => event[key])
+    .map((key) => map[key])
+
+  if (event.ctrlKey && lazy.AppConstants.platform === 'macosx') {
+    modifiers.push('MacCtrl')
+  }
+
+  return modifiers
+}

--- a/src/content/shared/lazy.ts
+++ b/src/content/shared/lazy.ts
@@ -10,6 +10,7 @@
 import { lazyESModuleGetters } from './TypedImportUtilities'
 
 export const lazy = lazyESModuleGetters({
+  AppConstants: 'resource://gre/modules/AppConstants.sys.mjs',
   PlacesUtils: 'resource://gre/modules/PlacesUtils.sys.mjs',
   Bookmarks: 'resource://gre/modules/Bookmarks.sys.mjs',
   History: 'resource://gre/modules/History.sys.mjs',

--- a/src/content/shared/search/providers/URLProvider.ts
+++ b/src/content/shared/search/providers/URLProvider.ts
@@ -6,6 +6,7 @@ import tld from './data/tld.txt'
 
 const HTTPS_REGEX =
   /^(?<protocol>https?:\/\/)?(?<domain>(\w+\.)+(?<tld>\w+))(?<path>\/.*)?$/m
+const EXTENSION_REGEX = /^moz-extension:\/\/.+$/m
 const CHROME_REGEX = /^chrome:\/\/.+$/m
 const ABOUT_REGEX = /^about:.+$/m
 const tlds = tld
@@ -19,7 +20,12 @@ const tlds = tld
  * @returns If the query is a url or not
  */
 export function isUrlLike(query: string): boolean {
-  if (ABOUT_REGEX.test(query) || CHROME_REGEX.test(query)) return true
+  if (
+    ABOUT_REGEX.test(query) ||
+    CHROME_REGEX.test(query) ||
+    EXTENSION_REGEX.test(query)
+  )
+    return true
   const match = HTTPS_REGEX.exec(query)
   if (match === null) return false
 
@@ -35,7 +41,11 @@ export class URLProvider extends Provider {
 
   public async getResults(query: string): Promise<ProviderResult[]> {
     // Check against chrome urls
-    if (CHROME_REGEX.test(query) || ABOUT_REGEX.test(query))
+    if (
+      CHROME_REGEX.test(query) ||
+      ABOUT_REGEX.test(query) ||
+      EXTENSION_REGEX.test(query)
+    )
       return [
         {
           title: query,

--- a/src/content/shared/xul/messageReciver.ts
+++ b/src/content/shared/xul/messageReciver.ts
@@ -1,0 +1,10 @@
+export class MessageReviver<
+  Cb extends (argument: ReceiveMessageArgument) => unknown,
+> implements MessageListener
+{
+  receiveMessage: Cb
+
+  constructor(callback: Cb) {
+    this.receiveMessage = callback
+  }
+}

--- a/src/content/shared/xul/messageReciver.ts
+++ b/src/content/shared/xul/messageReciver.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 export class MessageReviver<
   Cb extends (argument: ReceiveMessageArgument) => unknown,
 > implements MessageListener

--- a/src/link.d.ts
+++ b/src/link.d.ts
@@ -6,6 +6,9 @@
 
 /// <reference types="gecko-types" />
 
+/// <reference path="./types/MatchPattern.d.ts" />
+/// <reference path="./types/MessageManager.d.ts" />
+
 declare module 'resource://app/modules/FaviconLoader.sys.mjs' {
   export const FaviconLoader: typeof import('./modules/FaviconLoader').FaviconLoader
 }
@@ -82,6 +85,8 @@ declare interface XULBrowserElement extends HTMLElement {
 
   docShell: unknown
   swapDocShells(aOtherBrowser: XULBrowserElement)
+
+  messageManager: ChromeMessageSender
 }
 
 declare interface XULFindBarElement extends HTMLElement {
@@ -632,97 +637,3 @@ declare module ChromeUtils {
   ): T
 }
 
-interface MatchPatternOptions {
-  /**
-   * If true, the path portion of the pattern is ignored, and replaced with a
-   * wildcard. The `pattern` property is updated to reflect this.
-   */
-  ignorePath?: boolean
-
-  /**
-   * If true, the set of schemes this pattern can match is restricted to
-   * those accessible by WebExtensions.
-   */
-  restrictSchemes?: boolean
-}
-
-interface MatchPattern {
-  // eslint-disable-next-line @typescript-eslint/no-misused-new
-  constructor(pattern: string, options?: MatchPatternOptions)
-
-  /**
-   * Returns true if the given URI matches the pattern.
-   *
-   * If explicit is true, only explicit domain matches, without wildcards, are
-   * considered.
-   */
-  matches(uri: URI, explicit?: boolean): boolean
-  matches(url: string, explicit?: boolean): boolean
-
-  /**
-   * Returns true if a URL exists which a) would be able to access the given
-   * cookie, and b) would be matched by this match pattern.
-   */
-  matchesCookie(cookie: Cookie): boolean
-
-  /**
-   * Returns true if this pattern will match any host which would be matched
-   * by the given pattern.
-   */
-  subsumes(pattern: MatchPattern): boolean
-
-  /**
-   * Returns true if this pattern will match any host which would be matched
-   * by the given pattern, ignoring the scheme.
-   */
-  subsumesDomain(pattern: MatchPattern): boolean
-
-  /**
-   * Returns true if there is any host which would be matched by both this
-   * pattern and the given pattern.
-   */
-  overlaps(pattern: MatchPattern): boolean
-
-  /**
-   * The match pattern string represented by this pattern.
-   */
-  readonly pattern: string
-
-  /**
-   * Whether the match pattern matches all http(s) URLs.
-   */
-  readonly matchesAllWebUrls: boolean
-}
-
-class MatchPatternSet {
-  // eslint-disable-next-line @typescript-eslint/no-misused-new
-  constructor(
-    patterns: Array<string | MatchPattern>,
-    options?: MatchPatternOptions,
-  )
-
-  matches(uri: URI, explicit?: boolean): boolean
-  matches(url: string, explicit?: boolean): boolean
-
-  matchesCookie(cookie: Cookie): boolean
-
-  subsumes(pattern: MatchPattern): boolean
-
-  subsumesDomain(pattern: MatchPattern): boolean
-
-  overlaps(pattern: MatchPattern): boolean
-
-  overlaps(patternSet: MatchPatternSet): boolean
-
-  overlapsAll(patternSet: MatchPatternSet): boolean
-
-  readonly patterns: Array<MatchPattern>
-
-  readonly matchesAllWebUrls: boolean
-}
-
-declare global {
-  interface Window {
-    MatchPatternSet: typeof MatchPatternSet
-  }
-}

--- a/src/link.d.ts
+++ b/src/link.d.ts
@@ -21,14 +21,20 @@ declare module 'resource://app/modules/mitt.sys.mjs' {
   export default mitt
 }
 
+declare module 'resource://app/modules/EPageActions.sys.mjs' {
+  export * from './modules/EPageActions'
+}
+
 declare interface MozESMExportFile {
   TypedImportUtils: 'resource://app/modules/TypedImportUtils.sys.mjs'
   WindowTracker: 'resource://app/modules/BrowserWindowTracker.sys.mjs'
+  EPageActions: 'resource://app/modules/EPageActions.sys.mjs'
 }
 
 declare interface MozESMExportType {
   TypedImportUtils: typeof import('./modules/TypedImportUtils')
   WindowTracker: typeof import('./modules/BrowserWindowTracker').WindowTracker
+  EPageActions: typeof import('./modules/EPageActions').EPageActions
 }
 
 declare let Cr: Record<string, nsresult>
@@ -607,4 +613,20 @@ declare module 'resource://gre/modules/PlacesUtils.sys.mjs' {
      */
     function getLogger({ prefix }?: string): object
   }
+}
+
+
+declare module ChromeUtils {
+  /**
+   * Synchronously loads and evaluates the JS module source located at
+   * 'aResourceURI'.
+   *
+   * @param aResourceURI A resource:// URI string to load the module from.
+   * @returns the module's namespace object.
+   *
+   * The implementation maintains a hash of aResourceURI->global obj.
+   * Subsequent invocations of import with 'aResourceURI' pointing to
+   * the same file will not cause the module to be re-evaluated.
+   */
+  function importESModule<T extends import(Path), Path extends string>(path: Path): T
 }

--- a/src/link.d.ts
+++ b/src/link.d.ts
@@ -615,7 +615,6 @@ declare module 'resource://gre/modules/PlacesUtils.sys.mjs' {
   }
 }
 
-
 declare module ChromeUtils {
   /**
    * Synchronously loads and evaluates the JS module source located at
@@ -628,5 +627,102 @@ declare module ChromeUtils {
    * Subsequent invocations of import with 'aResourceURI' pointing to
    * the same file will not cause the module to be re-evaluated.
    */
-  function importESModule<T extends import(Path), Path extends string>(path: Path): T
+  function importESModule<T extends import(Path), Path extends string>(
+    path: Path,
+  ): T
+}
+
+interface MatchPatternOptions {
+  /**
+   * If true, the path portion of the pattern is ignored, and replaced with a
+   * wildcard. The `pattern` property is updated to reflect this.
+   */
+  ignorePath?: boolean
+
+  /**
+   * If true, the set of schemes this pattern can match is restricted to
+   * those accessible by WebExtensions.
+   */
+  restrictSchemes?: boolean
+}
+
+interface MatchPattern {
+  // eslint-disable-next-line @typescript-eslint/no-misused-new
+  constructor(pattern: string, options?: MatchPatternOptions)
+
+  /**
+   * Returns true if the given URI matches the pattern.
+   *
+   * If explicit is true, only explicit domain matches, without wildcards, are
+   * considered.
+   */
+  matches(uri: URI, explicit?: boolean): boolean
+  matches(url: string, explicit?: boolean): boolean
+
+  /**
+   * Returns true if a URL exists which a) would be able to access the given
+   * cookie, and b) would be matched by this match pattern.
+   */
+  matchesCookie(cookie: Cookie): boolean
+
+  /**
+   * Returns true if this pattern will match any host which would be matched
+   * by the given pattern.
+   */
+  subsumes(pattern: MatchPattern): boolean
+
+  /**
+   * Returns true if this pattern will match any host which would be matched
+   * by the given pattern, ignoring the scheme.
+   */
+  subsumesDomain(pattern: MatchPattern): boolean
+
+  /**
+   * Returns true if there is any host which would be matched by both this
+   * pattern and the given pattern.
+   */
+  overlaps(pattern: MatchPattern): boolean
+
+  /**
+   * The match pattern string represented by this pattern.
+   */
+  readonly pattern: string
+
+  /**
+   * Whether the match pattern matches all http(s) URLs.
+   */
+  readonly matchesAllWebUrls: boolean
+}
+
+class MatchPatternSet {
+  // eslint-disable-next-line @typescript-eslint/no-misused-new
+  constructor(
+    patterns: Array<string | MatchPattern>,
+    options?: MatchPatternOptions,
+  )
+
+  matches(uri: URI, explicit?: boolean): boolean
+  matches(url: string, explicit?: boolean): boolean
+
+  matchesCookie(cookie: Cookie): boolean
+
+  subsumes(pattern: MatchPattern): boolean
+
+  subsumesDomain(pattern: MatchPattern): boolean
+
+  overlaps(pattern: MatchPattern): boolean
+
+  overlaps(patternSet: MatchPatternSet): boolean
+
+  overlapsAll(patternSet: MatchPatternSet): boolean
+
+  readonly patterns: Array<MatchPattern>
+
+  readonly matchesAllWebUrls: boolean
+}
+
+declare global {
+  interface Window {
+    MatchPatternSet: typeof MatchPatternSet
+  }
 }

--- a/src/link.d.ts
+++ b/src/link.d.ts
@@ -6,8 +6,13 @@
 
 /// <reference types="gecko-types" />
 
+/// <reference path="./types/AppConstants.d.ts" />
 /// <reference path="./types/MatchPattern.d.ts" />
 /// <reference path="./types/MessageManager.d.ts" />
+
+declare type LazyImportType<Modules extends Partial<MozESMExportFile>> =
+  | { [Key in keyof Modules]: MozESMExportType[Key] }
+  | {}
 
 declare module 'resource://app/modules/FaviconLoader.sys.mjs' {
   export const FaviconLoader: typeof import('./modules/FaviconLoader').FaviconLoader
@@ -29,12 +34,14 @@ declare module 'resource://app/modules/EPageActions.sys.mjs' {
 }
 
 declare interface MozESMExportFile {
+  AppConstants: 'resource://gre/modules/AppConstants.sys.mjs'
   TypedImportUtils: 'resource://app/modules/TypedImportUtils.sys.mjs'
   WindowTracker: 'resource://app/modules/BrowserWindowTracker.sys.mjs'
   EPageActions: 'resource://app/modules/EPageActions.sys.mjs'
 }
 
 declare interface MozESMExportType {
+  AppConstants: typeof import('resource://gre/modules/AppConstants.sys.mjs').AppConstants
   TypedImportUtils: typeof import('./modules/TypedImportUtils')
   WindowTracker: typeof import('./modules/BrowserWindowTracker').WindowTracker
   EPageActions: typeof import('./modules/EPageActions').EPageActions
@@ -636,4 +643,3 @@ declare module ChromeUtils {
     path: Path,
   ): T
 }
-

--- a/src/modules/BrowserGlue.ts
+++ b/src/modules/BrowserGlue.ts
@@ -59,4 +59,26 @@ export class BrowserGlue {
     // eslint-disable-next-line no-console
     console.log({ aSubject, aTopic, aData })
   }
+
+  initializeDevtools() {
+    const { loader, require, DevToolsLoader } =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (ChromeUtils as any).importESModule(
+        'resource://devtools/shared/loader/Loader.sys.mjs',
+      )
+
+    const { DevToolsServer } = require('devtools/server/devtools-server')
+
+    // Make the loader visible to the debugger by default and for the already
+    // loaded instance. Thunderbird now also provides the Browser Toolbox for
+    // chrome debugging, which uses its own separate loader instance.
+    DevToolsLoader.prototype.invisibleToDebugger = false
+    loader.invisibleToDebugger = false
+    DevToolsServer.allowChromeProcess = true
+
+    // Initialize and load the toolkit/browser actors. This will also call above function to set the
+    // Thunderbird root actor
+    DevToolsServer.init()
+    DevToolsServer.registerAllActors()
+  }
 }

--- a/src/modules/BrowserWindowTracker.ts
+++ b/src/modules/BrowserWindowTracker.ts
@@ -1,17 +1,29 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import mitt from 'resource://app/modules/mitt.sys.mjs'
+
+type Tab = unknown
 
 export type WindowTrackerEvents = {
   windowCreated: Window & typeof globalThis
   windowDestroyed: Window & typeof globalThis
+
+  focus: Window & typeof globalThis
 }
 
 export const WindowTracker = {
+  /**
+   * @private
+   */
+  nextWindowId: 0,
+
   events: mitt<WindowTrackerEvents>(),
 
-  registeredWindows: new Map<string, typeof window>(),
+  activeWindow: null as number | null,
+  registeredWindows: new Map<number, typeof window>(),
 
   /**
    * Registers a new browser window to be tracked
@@ -19,18 +31,38 @@ export const WindowTracker = {
    * @param w The window to register
    */
   registerWindow(w: typeof window) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(w as any).windowApi.id = this.nextWindowId++
     this.registeredWindows.set((w as any).windowApi.id, w)
     this.events.emit('windowCreated', w)
   },
 
   removeWindow(w: typeof window) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.registeredWindows.delete((w as any).windowApi.id)
     this.events.emit('windowDestroyed', w)
   },
 
-  getWindowById(wid: string) {
+  getWindowById(wid: number) {
     return this.registeredWindows.get(wid)
+  },
+
+  getWindowWithBrowser(
+    browser: XULBrowserElement,
+  ): { window: Window & typeof globalThis; tab: Tab } | null {
+    for (const window of this.registeredWindows.values()) {
+      const tab = (window as any).windowApi.tabs.tabs.find(
+        (t: Tab) => (t as any).getTabId() === browser.browserId,
+      )
+      if (tab) return { window, tab }
+    }
+    return null
+  },
+
+  focusWindow(id: number) {
+    this.activeWindow = id
+    this.events.emit('focus', this.getActiveWindow()!)
+  },
+
+  getActiveWindow(): (typeof window & typeof globalThis) | undefined {
+    return this.registeredWindows.get(this.activeWindow ?? -1)
   },
 }

--- a/src/modules/EPageActions.ts
+++ b/src/modules/EPageActions.ts
@@ -57,6 +57,7 @@ export interface PageActionOptions<PS = MatchPatternSet> {
 
 export type PageActionEvents = {
   updateIcon: Record<number, string> | undefined
+  click: { clickData: { modifiers: string[]; button: number } }
 }
 
 export class PageAction implements PageActionOptions {

--- a/src/modules/EPageActions.ts
+++ b/src/modules/EPageActions.ts
@@ -4,7 +4,7 @@
 /// <reference path="../link.d.ts" />
 import mitt from 'resource://app/modules/mitt.sys.mjs'
 
-export type PageActionEvents = {
+export type PageActionsEvents = {
   register: {
     extension: string
     action: PageAction
@@ -51,13 +51,22 @@ export interface PageActionOptions<PS = MatchPatternSet> {
    * @key `hide_matches`
    */
   hideMatches?: PS
+
+  icons?: Record<number, string>
+}
+
+export type PageActionEvents = {
+  updateIcon: Record<number, string> | undefined
 }
 
 export class PageAction implements PageActionOptions {
+  events = mitt<PageActionEvents>()
+
   tooltip?: string
   popupUrl?: string
   showMatches: MatchPatternSet
   hideMatches: MatchPatternSet
+  icons?: Record<number, string>
 
   constructor(data: PageActionOptions<string[]>) {
     this.tooltip = data.tooltip
@@ -69,10 +78,15 @@ export class PageAction implements PageActionOptions {
   shouldShow(url: string) {
     return this.showMatches.matches(url) && !this.hideMatches.matches(url, true)
   }
+
+  setIcons(icons: Record<number, string>) {
+    this.icons = icons
+    this.events.emit('updateIcon', icons)
+  }
 }
 
 export const EPageActions = {
-  events: mitt<PageActionEvents>(),
+  events: mitt<PageActionsEvents>(),
 
   PageAction,
   pageActions: new Map<string, PageAction>(),

--- a/src/modules/EPageActions.ts
+++ b/src/modules/EPageActions.ts
@@ -69,6 +69,9 @@ export class PageAction implements PageActionOptions {
   hideMatches: MatchPatternSet
   icons?: Record<number, string>
 
+  showTabIds = new Set<number>()
+  hideTabIds = new Set<number>()
+
   constructor(data: PageActionOptions<string[]>) {
     this.tooltip = data.tooltip
     this.popupUrl = data.popupUrl
@@ -76,13 +79,29 @@ export class PageAction implements PageActionOptions {
     this.hideMatches = new MatchPatternSet(data.hideMatches || [])
   }
 
-  shouldShow(url: string) {
-    return this.showMatches.matches(url) && !this.hideMatches.matches(url, true)
+  shouldShow(url: string, tabId: number) {
+    const urlMatch =
+      this.showMatches.matches(url) &&
+      !this.hideMatches.matches(url, true) &&
+      !this.hideTabIds.has(tabId)
+    const idMatch = this.showTabIds.has(tabId)
+
+    return urlMatch || idMatch
   }
 
   setIcons(icons: Record<number, string>) {
     this.icons = icons
     this.events.emit('updateIcon', icons)
+  }
+
+  addShow(id: number) {
+    this.showTabIds.add(id)
+    this.hideTabIds.delete(id)
+  }
+
+  addHide(id: number) {
+    this.hideTabIds.add(id)
+    this.showTabIds.delete(id)
   }
 }
 

--- a/src/modules/EPageActions.ts
+++ b/src/modules/EPageActions.ts
@@ -26,7 +26,7 @@ export type PageActionEvents = {
  * @todo analytics to see how many page actions people have. If there are a few
  *       power users, we might want to implement `pinned`
  */
-export interface PageActionOptions {
+export interface PageActionOptions<PS = MatchPatternSet> {
   /**
    * The tooltip displayed when the user hovers over the action button.
    *
@@ -45,25 +45,29 @@ export interface PageActionOptions {
   /**
    * @key `show_matches`
    */
-  showMatches?: string[]
+  showMatches?: PS
 
   /**
    * @key `hide_matches`
    */
-  hideMatches?: string[]
+  hideMatches?: PS
 }
 
 export class PageAction implements PageActionOptions {
   tooltip?: string
   popupUrl?: string
-  showMatches?: string[]
-  hideMatches?: string[]
+  showMatches: MatchPatternSet
+  hideMatches: MatchPatternSet
 
-  constructor(data: PageActionOptions) {
+  constructor(data: PageActionOptions<string[]>) {
     this.tooltip = data.tooltip
     this.popupUrl = data.popupUrl
-    this.showMatches = data.showMatches
-    this.hideMatches = data.hideMatches
+    this.showMatches = new MatchPatternSet(data.showMatches || [])
+    this.hideMatches = new MatchPatternSet(data.hideMatches || [])
+  }
+
+  shouldShow(url: string) {
+    return this.showMatches.matches(url) && !this.hideMatches.matches(url, true)
   }
 }
 

--- a/src/modules/EPageActions.ts
+++ b/src/modules/EPageActions.ts
@@ -32,11 +32,13 @@ export interface PageActionOptions {
    *
    * @key `default_title`
    */
-  tooltip: string
+  tooltip?: string
 
   /**
    * The url of the popup to show when the icon is clicked. If this url does not
    * exist, clicking the icon will send an event back to the extension.
+   *
+   * @key `default_popup`
    */
   popupUrl?: string
 
@@ -52,10 +54,10 @@ export interface PageActionOptions {
 }
 
 export class PageAction implements PageActionOptions {
-  tooltip: string
-  popupUrl?: string | undefined
-  showMatches?: string[] | undefined
-  hideMatches?: string[] | undefined
+  tooltip?: string
+  popupUrl?: string
+  showMatches?: string[]
+  hideMatches?: string[]
 
   constructor(data: PageActionOptions) {
     this.tooltip = data.tooltip
@@ -65,28 +67,29 @@ export class PageAction implements PageActionOptions {
   }
 }
 
-export const PageActions = {
+export const EPageActions = {
   events: mitt<PageActionEvents>(),
 
+  PageAction,
   pageActions: new Map<string, PageAction>(),
 
   registerPageAction(extensionId: string, pageAction: PageAction) {
-    if (PageActions.pageActions.has(extensionId)) {
-      PageActions.removePageAction(extensionId)
+    if (EPageActions.pageActions.has(extensionId)) {
+      EPageActions.removePageAction(extensionId)
     }
 
-    PageActions.pageActions.set(extensionId, pageAction)
-    PageActions.events.emit('register', {
+    EPageActions.pageActions.set(extensionId, pageAction)
+    EPageActions.events.emit('register', {
       action: pageAction,
       extension: extensionId,
     })
   },
 
   removePageAction(extensionId: string) {
-    const action = PageActions.pageActions.get(extensionId)
+    const action = EPageActions.pageActions.get(extensionId)
     if (!action) return
 
-    PageActions.pageActions.delete(extensionId)
-    PageActions.events.emit('remove', { action, extension: extensionId })
+    EPageActions.pageActions.delete(extensionId)
+    EPageActions.events.emit('remove', { action, extension: extensionId })
   },
 }

--- a/src/modules/PageActions.ts
+++ b/src/modules/PageActions.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/// <reference path="../link.d.ts" />
+import mitt from 'resource://app/modules/mitt.sys.mjs'
+
+export type PageActionEvents = {
+  register: {
+    extension: string
+    action: PageAction
+  }
+
+  remove: {
+    extension: string
+    action: PageAction
+  }
+}
+
+/**
+ * The following features are not going to be supported, primarily because I see
+ * no good reason for including support
+ * - `browser_style`: There is no documentation for this, provide a browser
+ *                    style component library instead
+ * - `pinned`: For the moment, I don't feel like pinning page actions
+ *
+ * @todo analytics to see how many page actions people have. If there are a few
+ *       power users, we might want to implement `pinned`
+ */
+export interface PageActionOptions {
+  /**
+   * The tooltip displayed when the user hovers over the action button.
+   *
+   * @key `default_title`
+   */
+  tooltip: string
+
+  /**
+   * The url of the popup to show when the icon is clicked. If this url does not
+   * exist, clicking the icon will send an event back to the extension.
+   */
+  popupUrl?: string
+
+  /**
+   * @key `show_matches`
+   */
+  showMatches?: string[]
+
+  /**
+   * @key `hide_matches`
+   */
+  hideMatches?: string[]
+}
+
+export class PageAction implements PageActionOptions {
+  tooltip: string
+  popupUrl?: string | undefined
+  showMatches?: string[] | undefined
+  hideMatches?: string[] | undefined
+
+  constructor(data: PageActionOptions) {
+    this.tooltip = data.tooltip
+    this.popupUrl = data.popupUrl
+    this.showMatches = data.showMatches
+    this.hideMatches = data.hideMatches
+  }
+}
+
+export const PageActions = {
+  events: mitt<PageActionEvents>(),
+
+  pageActions: new Map<string, PageAction>(),
+
+  registerPageAction(extensionId: string, pageAction: PageAction) {
+    if (PageActions.pageActions.has(extensionId)) {
+      PageActions.removePageAction(extensionId)
+    }
+
+    PageActions.pageActions.set(extensionId, pageAction)
+    PageActions.events.emit('register', {
+      action: pageAction,
+      extension: extensionId,
+    })
+  },
+
+  removePageAction(extensionId: string) {
+    const action = PageActions.pageActions.get(extensionId)
+    if (!action) return
+
+    PageActions.pageActions.delete(extensionId)
+    PageActions.events.emit('remove', { action, extension: extensionId })
+  },
+}

--- a/src/modules/link.json
+++ b/src/modules/link.json
@@ -1,1 +1,7 @@
-["BrowserGlue", "BrowserWindowTracker", "FaviconLoader", "TypedImportUtils"]
+[
+  "BrowserGlue",
+  "BrowserWindowTracker",
+  "EPageActions",
+  "FaviconLoader",
+  "TypedImportUtils"
+]

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -109,6 +109,9 @@ pref('browser.download.alwaysOpenPanel', true);
 //   2 - Remove the download from both session list and history.
 pref('browser.download.clearHistoryOnDelete', 0);
 
+// We do this because we want page actions etc. to have color schemes
+pref('svg.context-properties.content.enabled', true);
+
 // =============================================================================
 // Multithreading
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -108,3 +108,13 @@ pref('browser.download.alwaysOpenPanel', true);
 //   1 - Remove the download from session list, but not history.
 //   2 - Remove the download from both session list and history.
 pref('browser.download.clearHistoryOnDelete', 0);
+
+// =============================================================================
+// Multithreading
+
+pref('browser.tabs.remote.autostart', true);
+pref('browser.tabs.remote.separatePrivilegedContentProcess', true);
+pref('browser.tabs.remote.separatePrivilegedMozillaWebContentProcess', true);
+
+pref('extensions.webextensions.remote', true);
+pref('extensions.webextensions.protocol.remote', true);

--- a/src/types/AppConstants.d.ts
+++ b/src/types/AppConstants.d.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+type AppConstantsContents = {
+  readonly NIGHTLY_BUILD: boolean
+  readonly RELEASE_OR_BETA: boolean
+  readonly EARLY_BETA_OR_EARLIER: boolean
+  readonly IS_ESR: boolean
+  readonly ACCESSIBILITY: boolean
+  readonly MOZILLA_OFFICIAL: boolean
+  readonly MOZ_OFFICIAL_BRANDING: boolean
+  readonly MOZ_DEV_EDITION: boolean
+  readonly MOZ_SERVICES_SYNC: boolean
+  readonly MOZ_SERVICES_HEALTHREPORT: boolean
+  readonly MOZ_DATA_REPORTING: boolean
+  readonly MOZ_SANDBOX: boolean
+  readonly MOZ_TELEMETRY_REPORTING: boolean
+  readonly MOZ_TELEMETRY_ON_BY_DEFAULT: boolean
+  readonly MOZ_UPDATER: boolean
+  readonly MOZ_SWITCHBOARD: boolean
+  readonly MOZ_WEBRTC: boolean
+  readonly MOZ_WIDGET_GTK: boolean
+  readonly MOZ_WMF_CDM: boolean
+  readonly XP_UNIX: boolean
+  readonly platform: string
+  readonly unixstyle: boolean
+
+  isPlatformAndVersionAtLeast(platform: string, version: string): boolean
+  isPlatformAndVersionAtMost(platform: string, version: string): boolean
+
+  readonly MOZ_CRASHREPORTER: boolean
+  readonly MOZ_NORMANDY: boolean
+  readonly MOZ_MAINTENANCE_SERVICE: boolean
+  readonly MOZ_BACKGROUNDTASKS: boolean
+  readonly MOZ_UPDATE_AGENT: boolean
+  readonly MOZ_BITS_DOWNLOAD: boolean
+  readonly DEBUG: boolean
+  readonly ASAN: boolean
+  readonly ASAN_REPORTER: boolean
+  readonly TSAN: boolean
+  readonly MOZ_SYSTEM_NSS: boolean
+  readonly MOZ_PLACES: boolean
+  readonly MOZ_REQUIRE_SIGNING: boolean
+  readonly MOZ_UNSIGNED_SCOPES: number
+  readonly MOZ_ALLOW_ADDON_SIDELOAD: boolean
+  readonly MOZ_WEBEXT_WEBIDL_ENABLED: boolean
+  readonly MENUBAR_CAN_AUTOHIDE: boolean
+  readonly MOZ_ANDRIOD_HISTORY: boolean
+  readonly MOZ_GECKO_PROFILER: boolean
+
+  readonly DLL_PREFIX: string
+  readonly DLL_SUFFIX: string
+  readonly MOZ_APP_NAME: string
+  readonly MOZ_APP_BASENAME: string
+  /**
+   * @deprecated use brandShortName/brand-short-name instead
+   */
+  readonly MOZ_APP_DISPLAYNAME_DO_NOT_USE: string
+  readonly MOZ_APP_VERSION: string
+  readonly MOZ_APP_VERSION_DISPLAY: string
+  readonly MOZ_BUILDID: string
+  readonly MOZ_BUILD_APP: string
+  readonly MOZ_MACBUNDLE_ID: string
+  readonly MOZ_MACBUNDLE_NAME: string
+  readonly MOZ_UPDATE_CHANNEL: string
+  readonly MOZ_WIDGET_TOOLKIT: string
+  readonly ANDROID_PACKAGE_NAME: string
+
+  readonly DEBUG_JS_MODULES: string
+
+  readonly MOZ_BING_API_CLIENTID: string
+  readonly MOZ_BING_API_KEY: string
+  readonly MOZ_GOOGLE_LOCATION_SERVICE_API_KEY: string
+  readonly MOZ_GOOGLE_SAFEBROWSING_API_KEY: string
+  readonly MOZ_MOZILLA_API_KEY: string
+
+  readonly BROWSER_CHROME_URL: string
+
+  readonly OMNIJAR_NAME: string
+
+  readonly HAVE_SHELL_SERVICE: boolean
+  readonly MOZ_CODE_COVERAGE: boolean
+  readonly TELEMETRY_PING_FORMAT_VERSION: string
+  readonly MOZ_NEW_NOTIFICATION_STORE: boolean
+  readonly ENABLE_WEBDRIVER: boolean
+  readonly REMOTE_SETTINGS_SERVER_URL: string
+  readonly REMOTE_SETTINGS_VERIFY_SIGNATURE: boolean
+  readonly REMOTE_SETTINGS_DEFAULT_BUCKET: string
+  readonly MOZ_GLEAN_ANDROID: boolean
+  readonly MOZ_JXL: boolean
+  readonly MOZ_CAN_FOLLOW_SYSTEM_TIME: boolean
+  readonly MOZ_SYSTEM_POLICIES: boolean
+}
+
+declare module 'resource://gre/modules/AppConstants.sys.mjs' {
+  export const AppConstants: AppConstantsContents
+}

--- a/src/types/MatchPattern.d.ts
+++ b/src/types/MatchPattern.d.ts
@@ -1,0 +1,94 @@
+interface MatchPatternOptions {
+  /**
+   * If true, the path portion of the pattern is ignored, and replaced with a
+   * wildcard. The `pattern` property is updated to reflect this.
+   */
+  ignorePath?: boolean
+
+  /**
+   * If true, the set of schemes this pattern can match is restricted to
+   * those accessible by WebExtensions.
+   */
+  restrictSchemes?: boolean
+}
+
+interface MatchPattern {
+  // eslint-disable-next-line @typescript-eslint/no-misused-new
+  constructor(pattern: string, options?: MatchPatternOptions)
+
+  /**
+   * Returns true if the given URI matches the pattern.
+   *
+   * If explicit is true, only explicit domain matches, without wildcards, are
+   * considered.
+   */
+  matches(uri: URI, explicit?: boolean): boolean
+  matches(url: string, explicit?: boolean): boolean
+
+  /**
+   * Returns true if a URL exists which a) would be able to access the given
+   * cookie, and b) would be matched by this match pattern.
+   */
+  matchesCookie(cookie: Cookie): boolean
+
+  /**
+   * Returns true if this pattern will match any host which would be matched
+   * by the given pattern.
+   */
+  subsumes(pattern: MatchPattern): boolean
+
+  /**
+   * Returns true if this pattern will match any host which would be matched
+   * by the given pattern, ignoring the scheme.
+   */
+  subsumesDomain(pattern: MatchPattern): boolean
+
+  /**
+   * Returns true if there is any host which would be matched by both this
+   * pattern and the given pattern.
+   */
+  overlaps(pattern: MatchPattern): boolean
+
+  /**
+   * The match pattern string represented by this pattern.
+   */
+  readonly pattern: string
+
+  /**
+   * Whether the match pattern matches all http(s) URLs.
+   */
+  readonly matchesAllWebUrls: boolean
+}
+
+class MatchPatternSet {
+  // eslint-disable-next-line @typescript-eslint/no-misused-new
+  constructor(
+    patterns: Array<string | MatchPattern>,
+    options?: MatchPatternOptions,
+  )
+
+  matches(uri: URI, explicit?: boolean): boolean
+  matches(url: string, explicit?: boolean): boolean
+
+  matchesCookie(cookie: Cookie): boolean
+
+  subsumes(pattern: MatchPattern): boolean
+
+  subsumesDomain(pattern: MatchPattern): boolean
+
+  overlaps(pattern: MatchPattern): boolean
+
+  overlaps(patternSet: MatchPatternSet): boolean
+
+  overlapsAll(patternSet: MatchPatternSet): boolean
+
+  readonly patterns: Array<MatchPattern>
+
+  readonly matchesAllWebUrls: boolean
+}
+
+declare global {
+  interface Window {
+    MatchPatternSet: typeof MatchPatternSet
+  }
+}

--- a/src/types/MatchPattern.d.ts
+++ b/src/types/MatchPattern.d.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 interface MatchPatternOptions {
   /**
    * If true, the path portion of the pattern is ignored, and replaced with a

--- a/src/types/MessageManager.d.ts
+++ b/src/types/MessageManager.d.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/// <reference types="gecko-types" />
+
+type nsIEventTarget = nsIEventTargetType
+interface Principal {}
+
+type nsISupports = nsISupportsType
+
+interface FrameLoader {}
+
+interface MessagePort {}
+
+declare interface ReceiveMessageArgument {
+  target: nsISupports
+  name: string
+  sync: boolean
+  data?: any
+  json?: any
+  ports: MessagePort[]
+  targetFrameLoader?: FrameLoader
+}
+
+declare interface MessageListener {
+  receiveMessage(argument: ReceiveMessageArgument): any
+}
+
+declare interface MessageListenerManagerMixin {
+  addMessageListener(
+    messageName: string,
+    listener: MessageListener,
+    listenWhenClosed?: boolean,
+  ): void
+  removeMessageListener(messageName: string, listener: MessageListener): void
+  addWeakMessageListener(messageName: string, listener: MessageListener): void
+  removeWeakMessageListener(
+    messageName: string,
+    listener: MessageListener,
+  ): void
+}
+
+declare interface MessageListenerManager extends MessageListenerManagerMixin {}
+
+declare interface MessageSenderMixin {
+  sendAsyncMessage(messageName?: string, obj?: any, transfers?: any): void
+  readonly processMessageManager?: MessageSender
+  readonly remoteType: string
+}
+
+declare interface MessageSender
+  extends MessageListenerManager,
+    MessageSenderMixin {}
+
+declare interface SyncMessageSenderMixin {
+  sendSyncMessage(messageName?: string, obj?: any): any[]
+}
+
+declare interface SyncMessageSender
+  extends MessageSender,
+    SyncMessageSenderMixin {}
+
+declare interface ChildProcessMessageManager extends SyncMessageSender {}
+
+declare interface MessageManagerGlobal {
+  dump(str: string): void
+  atob(asciiString: string): string
+  btoa(base64Data: string): string
+}
+
+declare interface FrameScriptLoader {
+  loadFrameScript(
+    url: string,
+    allowDelayedLoad: boolean,
+    runInGlobalScope?: boolean,
+  ): void
+  removeDelayedFrameScript(url: string): void
+  getDelayedFrameScripts(): any[][]
+}
+
+declare interface ProcessScriptLoader {
+  loadProcessScript(url: string, allowDelayedLoad: boolean): void
+  removeDelayedProcessScript(url: string): void
+  getDelayedProcessScripts(): any[][]
+}
+
+declare interface GlobalProcessScriptLoader {
+  readonly initialProcessData: any
+  readonly sharedData: any
+}
+
+declare interface ContentFrameMessageManager
+  extends EventTarget,
+    MessageManagerGlobal,
+    SyncMessageSenderMixin,
+    MessageSenderMixin,
+    MessageListenerManagerMixin {
+  readonly content?: Window
+  readonly docShell?: any
+  readonly tabEventTarget?: nsIEventTarget
+}
+
+declare interface ContentProcessMessageManager
+  extends MessageManagerGlobal,
+    SyncMessageSenderMixin,
+    MessageSenderMixin,
+    MessageListenerManagerMixin {
+  readonly initialProcessData: any
+  readonly sharedData?: any
+}
+
+declare interface MessageBroadcaster extends MessageListenerManager {
+  broadcastAsyncMessage(messageName?: string, obj?: any): void
+  readonly childCount: number
+  getChildAt(aIndex: number): MessageListenerManager | null
+  releaseCachedProcesses(): void
+}
+
+declare interface ChromeMessageBroadcaster
+  extends MessageBroadcaster,
+    FrameScriptLoader {}
+
+declare interface ParentProcessMessageManager
+  extends MessageBroadcaster,
+    ProcessScriptLoader,
+    GlobalProcessScriptLoader {}
+
+declare interface ChromeMessageSender
+  extends MessageSender,
+    FrameScriptLoader {}
+
+declare interface ProcessMessageManager
+  extends MessageSender,
+    ProcessScriptLoader {
+  readonly osPid: number
+  readonly isInProcess: boolean
+}

--- a/src/types/MessageManager.d.ts
+++ b/src/types/MessageManager.d.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /// <reference types="gecko-types" />
 

--- a/static/chrome/en-US/locale/branding/brand.properties
+++ b/static/chrome/en-US/locale/branding/brand.properties
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+brandShorterName=Experiment
+brandShortName=Experiment
+brandFullName=Experiment

--- a/static/chrome/link.json
+++ b/static/chrome/link.json
@@ -1,0 +1,1 @@
+["en-US/locale/branding/brand.properties"]

--- a/static/extensions/ext-browser.json
+++ b/static/extensions/ext-browser.json
@@ -3,6 +3,7 @@
     "url": "chrome://browser/content/extensions/parent/ext-pageAction.js",
     "schema": "chrome://extensions/content/schemas/page_action.json",
     "scopes": ["addon_parent"],
-    "manifest": ["page_action"]
+    "manifest": ["page_action"],
+    "paths": [["pageAction"]]
   }
 }

--- a/static/extensions/ext-browser.json
+++ b/static/extensions/ext-browser.json
@@ -1,0 +1,8 @@
+{
+  "pageAction": {
+    "url": "chrome://browser/content/extensions/parent/ext-pageAction.js",
+    "schema": "chrome://extensions/content/schemas/page_action.json",
+    "scopes": ["addon_parent"],
+    "manifest": ["page_action"]
+  }
+}

--- a/static/extensions/parent/ext-browser.js
+++ b/static/extensions/parent/ext-browser.js
@@ -1,0 +1,58 @@
+// @ts-check
+/* eslint-disable no-undef */
+/// <reference path="../types/index.d.ts" />
+
+/** @type {typeof import('resource://app/modules/TypedImportUtils.sys.mjs')} */
+const typedImportUtils = ChromeUtils.importESModule(
+  'resource://app/modules/TypedImportUtils.sys.mjs',
+)
+const { lazyESModuleGetters } = typedImportUtils
+
+const lazy = lazyESModuleGetters({
+  WindowTracker: 'resource://app/modules/BrowserWindowTracker.sys.mjs',
+  EPageActions: 'resource://app/modules/EPageActions.sys.mjs',
+  ExtensionParent: 'resource://gre/modules/ExtensionParent.sys.mjs',
+})
+
+class TabTracker extends TabTrackerBase {
+  get activeTab() {
+    /** @type {any | null} */
+    const window = lazy.WindowTracker.getActiveWindow()
+    return window?.windowApi?.tabs?.getCurrentTab()
+  }
+
+  init() {
+    if (this.initialized) return
+    this.initialized = true
+  }
+
+  /**
+   * @param {*} nativeTab
+   */
+  getId(nativeTab) {
+    return nativeTab.getTabId()
+  }
+
+  getTab(tabId, default_) {
+    const { tab } = lazy.WindowTracker.getWindowWithBrowser(tabId) || {
+      tab: default_,
+    }
+
+    return tab
+  }
+
+  getBrowserData(browser) {
+    const data = lazy.WindowTracker.getWindowWithBrowser(browser)
+    if (!data) return { windowId: -1, tabId: -1 }
+
+    return {
+      /** @type {number} */
+      // @ts-expect-error bad imported types
+      windowId: data.window.windowApi.id,
+      /** @type {number} */
+      tabId: data.tab.getTabId(),
+    }
+  }
+}
+
+Object.assign(global, { tabTracker: new TabTracker() })

--- a/static/extensions/parent/ext-browser.js
+++ b/static/extensions/parent/ext-browser.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @ts-check
 /* eslint-disable no-undef */
 /// <reference path="../types/index.d.ts" />

--- a/static/extensions/parent/ext-pageAction.js
+++ b/static/extensions/parent/ext-pageAction.js
@@ -2,12 +2,31 @@
 // @ts-check
 /// <reference path="../types/index.d.ts" />
 
+/** @type {typeof import('resource://app/modules/TypedImportUtils.sys.mjs')} */
+const typedImportUtils = ChromeUtils.importESModule(
+  'resource://app/modules/TypedImportUtils.sys.mjs',
+)
+const { lazyESModuleGetters } = typedImportUtils
+
+const lazy = lazyESModuleGetters({
+  EPageActions: 'resource://app/modules/EPageActions.sys.mjs',
+})
+
 this.pageAction = class extends ExtensionAPIPersistent {
   async onManifestEntry(entryName) {
     const { extension } = this
     const options = extension.manifest.page_action
 
-    console.log(entryName, options)
+    console.log(entryName, options, extension)
+
+    const pageAction = new lazy.EPageActions.PageAction({
+      tooltip: options.default_title,
+      popupUrl: options.default_popup,
+      showMatches: options.matches,
+      hideMatches: options.exclude_matches,
+    })
+
+    lazy.EPageActions.registerPageAction(extension.id, pageAction)
   }
 }
 

--- a/static/extensions/parent/ext-pageAction.js
+++ b/static/extensions/parent/ext-pageAction.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-undef */
+// @ts-check
+/// <reference path="../types/index.d.ts" />
+
+this.pageAction = class extends ExtensionAPIPersistent {
+  async onManifestEntry(entryName) {
+    const { extension } = this
+    const options = extension.manifest.page_action
+
+    console.log(entryName, options)
+  }
+}
+
+// global.pageActionFor = this.pageAction.for

--- a/static/extensions/parent/ext-pageAction.js
+++ b/static/extensions/parent/ext-pageAction.js
@@ -28,6 +28,11 @@ this.pageAction = class extends ExtensionAPIPersistent {
 
     lazy.EPageActions.registerPageAction(extension.id, pageAction)
   }
+
+  onShutdown() {
+    const { extension } = this
+    lazy.EPageActions.removePageAction(extension.id)
+  }
 }
 
 // global.pageActionFor = this.pageAction.for

--- a/static/extensions/parent/ext-pageAction.js
+++ b/static/extensions/parent/ext-pageAction.js
@@ -2,17 +2,6 @@
 // @ts-check
 /// <reference path="../types/index.d.ts" />
 
-/** @type {typeof import('resource://app/modules/TypedImportUtils.sys.mjs')} */
-const typedImportUtils = ChromeUtils.importESModule(
-  'resource://app/modules/TypedImportUtils.sys.mjs',
-)
-const { lazyESModuleGetters } = typedImportUtils
-
-const lazy = lazyESModuleGetters({
-  EPageActions: 'resource://app/modules/EPageActions.sys.mjs',
-  ExtensionParent: 'resource://gre/modules/ExtensionParent.sys.mjs',
-})
-
 this.pageAction = class extends ExtensionAPIPersistent {
   async onManifestEntry(entryName) {
     const { extension } = this
@@ -38,12 +27,76 @@ this.pageAction = class extends ExtensionAPIPersistent {
       ),
     )
 
+    pageAction.events.on('click', (v) => {
+      console.log('Click Value', v)
+      this.emit('click', v)
+    })
+
     lazy.EPageActions.registerPageAction(extension.id, pageAction)
   }
 
   onShutdown() {
     const { extension } = this
     lazy.EPageActions.removePageAction(extension.id)
+  }
+
+  PERSISTENT_EVENTS = {
+    /**
+     * @param {object}             options
+     * @param {object}             options.fire
+     * @param {function}           options.fire.async
+     * @param {function}           options.fire.sync
+     * @param {function}           options.fire.raw
+     *        For primed listeners `fire.async`/`fire.sync`/`fire.raw` will
+     *        collect the pending events to be send to the background context
+     *        and implicitly wake up the background context (Event Page or
+     *        Background Service Worker), or forward the event right away if
+     *        the background context is running.
+     * @param {function}           [options.fire.wakeup = undefined]
+     *        For primed listeners, the `fire` object also provide a `wakeup` method
+     *        which can be used by the primed listener to explicitly `wakeup` the
+     *        background context (Event Page or Background Service Worker) and wait for
+     *        it to be running (by awaiting on the Promise returned by wakeup to be
+     *        resolved).
+     * @param {ProxyContextParent} [options.context=undefined]
+     *        This property is expected to be undefined for primed listeners (which
+     *        are created while the background extension context does not exist) and
+     *        to be set to a ProxyContextParent instance (the same got by the getAPI
+     *        method) when the method is called for a listener registered by a
+     *        running extension context.
+     */
+    onClicked({ fire }) {
+      const callback = async (_name, clickInfo) => {
+        console.log(fire, fire.wakeup, !!fire.wakeup)
+        if (fire.wakeup) await fire.wakeup()
+        console.log('fire')
+        fire.sync(clickInfo)
+      }
+
+      this.on('click', callback)
+      return {
+        unregister: () => {
+          this.off('click', callback)
+        },
+        convert(newFire) {
+          fire = newFire
+        },
+      }
+    },
+  }
+
+  getAPI(context) {
+    return {
+      pageAction: {
+        onClicked: new EventManager({
+          context,
+          module: 'pageAction',
+          event: 'onClicked',
+          inputHandling: true,
+          extensionApi: this,
+        }).api(),
+      },
+    }
   }
 }
 

--- a/static/extensions/parent/ext-pageAction.js
+++ b/static/extensions/parent/ext-pageAction.js
@@ -10,6 +10,7 @@ const { lazyESModuleGetters } = typedImportUtils
 
 const lazy = lazyESModuleGetters({
   EPageActions: 'resource://app/modules/EPageActions.sys.mjs',
+  ExtensionParent: 'resource://gre/modules/ExtensionParent.sys.mjs',
 })
 
 this.pageAction = class extends ExtensionAPIPersistent {
@@ -25,6 +26,17 @@ this.pageAction = class extends ExtensionAPIPersistent {
       showMatches: options.show_matches,
       hideMatches: options.hide_matches,
     })
+
+    pageAction.setIcons(
+      lazy.ExtensionParent.IconDetails.normalize(
+        {
+          path: options.default_icon || extension.manifest.icons,
+          iconType: 'browserAction',
+          themeIcon: options.theme_icons || extension.theme_icons,
+        },
+        extension,
+      ),
+    )
 
     lazy.EPageActions.registerPageAction(extension.id, pageAction)
   }

--- a/static/extensions/parent/ext-pageAction.js
+++ b/static/extensions/parent/ext-pageAction.js
@@ -22,8 +22,8 @@ this.pageAction = class extends ExtensionAPIPersistent {
     const pageAction = new lazy.EPageActions.PageAction({
       tooltip: options.default_title,
       popupUrl: options.default_popup,
-      showMatches: options.matches,
-      hideMatches: options.exclude_matches,
+      showMatches: options.show_matches,
+      hideMatches: options.hide_matches,
     })
 
     lazy.EPageActions.registerPageAction(extension.id, pageAction)

--- a/static/extensions/sharedTypes.d.ts
+++ b/static/extensions/sharedTypes.d.ts
@@ -1,0 +1,34 @@
+/**
+ * The following features are not going to be supported, primarily because I see
+ * no good reason for including support
+ * - `browser_style`: There is no documentation for this, provide a browser
+ *                    style component library instead
+ * - `pinned`: For the moment, I don't feel like pinning page actions
+ *
+ * @todo analytics to see how many page actions people have. If there are a few
+ *       power users, we might want to implement `pinned`
+ */
+export type PageAction = {
+  /**
+   * The tooltip displayed when the user hovers over the action button.
+   *
+   * @key `default_title`
+   */
+  tooltip: string
+
+  /**
+   * The url of the popup to show when the icon is clicked. If this url does not
+   * exist, clicking the icon will send an event back to the extension.
+   */
+  popupUrl?: string
+
+  /**
+   * @key `show_matches
+   */
+  showMatches?: string[]
+
+  /**
+   * @key `hide_matches`
+   */
+  hideMatches?: string[]
+}

--- a/static/extensions/sharedTypes.d.ts
+++ b/static/extensions/sharedTypes.d.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
  * The following features are not going to be supported, primarily because I see
  * no good reason for including support

--- a/static/extensions/types/ConduitChild.d.ts
+++ b/static/extensions/types/ConduitChild.d.ts
@@ -1,0 +1,146 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * This @file implements the child side of Conduits, an abstraction over
+ * Fission IPC for extension API subject.  See {@link ConduitsParent.jsm}
+ * for more details about the overall design.
+ */
+import {
+  ConduitAddress,
+  ConduitID,
+} from 'resource://gre/modules/ConduitsParent.sys.mjs'
+
+type JSWindowActor = unknown
+
+/**
+ * Base class for both child (Point) and parent (Broadcast) side of conduits,
+ * handles setting up send/receive method stubs.
+ */
+export class BaseConduit {
+  /**
+   * @param {object} subject
+   * @param {ConduitAddress} address
+   */
+  constructor(subject: object, address: ConduitAddress)
+  subject: object
+  address: ConduitAddress
+  id: any
+  recv: Map<any, any>
+  /**
+   * Internal, partially @abstract, uses the actor to send the message/query.
+   *
+   * @param {string} method
+   * @param {boolean} query Flag indicating a response is expected.
+   * @param {JSWindowActor} actor
+   * @param {MessageData} data
+   * @returns {Promise?}
+   */
+  _send(
+    method: string,
+    query: boolean,
+    actor: JSWindowActor,
+    data: MessageData,
+  ): Promise<any> | null
+  /**
+   * Internal, calls the specific recvX method based on the message.
+   *
+   * @param {string} name Message/method name.
+   * @param {object} arg  Message data, the one and only method argument.
+   * @param {object} meta Metadata about the method call.
+   */
+  _recv(name: string, arg: object, meta: object): Promise<any>
+}
+/**
+ * Child side conduit, can only send/receive point-to-point messages via the
+ * one specific ConduitsChild actor.
+ */
+export class PointConduit extends BaseConduit {
+  constructor(subject: any, address: any, actor: any)
+  actor: any
+  /**
+   * Internal, sends messages via the actor, used by sendX stubs.
+   *
+   * @param {string} method
+   * @param {boolean} query
+   * @param {object?} arg
+   * @returns {Promise?}
+   */
+  _send(
+    method: string,
+    query: boolean,
+    arg?: object | null,
+  ): Promise<any> | null
+  /**
+   * Closes the conduit from further IPC, notifies the parent side by default.
+   *
+   * @param {boolean} silent
+   */
+  close(silent?: boolean): void
+  closeCallback: Function
+  /**
+   * Set the callback to be called when the conduit is closed.
+   *
+   * @param {Function} callback
+   */
+  setCloseCallback(callback: Function): void
+}
+/**
+ * Implements the child side of the Conduits actor, manages conduit lifetimes.
+ */
+export class ConduitsChild {
+  conduits: Map<any, any>
+  /**
+   * Public entry point a child-side subject uses to open a conduit.
+   *
+   * @param {object} subject
+   * @param {ConduitAddress} address
+   * @returns {PointConduit}
+   */
+  openConduit(subject: object, address: ConduitAddress): PointConduit
+  /**
+   * JSWindowActor method, routes the message to the target subject.
+   *
+   * @param {object} options
+   * @param {string} options.name
+   * @param {MessageData | MessageData[]} options.data
+   * @returns {Promise?}
+   */
+  receiveMessage({
+    name,
+    data,
+  }: {
+    name: string
+    data: MessageData | MessageData[]
+  }): Promise<any> | null
+  /**
+   * JSWindowActor method, ensure cleanup.
+   */
+  didDestroy(): void
+}
+/**
+ * Child side of the Conduits process actor.  Same code as JSWindowActor.
+ */
+export class ProcessConduitsChild {
+  conduits: Map<any, any>
+  openConduit: (subject: object, address: ConduitAddress) => PointConduit
+  receiveMessage: ({
+    name,
+    data,
+  }: {
+    name: string
+    data: MessageData | MessageData[]
+  }) => Promise<any>
+  willDestroy: any
+  didDestroy: () => void
+}
+/**
+ * This
+ */
+export type MessageData = {
+  target?: ConduitID
+  sender?: ConduitID
+  query: boolean
+  arg: object
+}

--- a/static/extensions/types/ConduitChild.d.ts
+++ b/static/extensions/types/ConduitChild.d.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* eslint-disable @typescript-eslint/ban-types */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/static/extensions/types/index.d.ts
+++ b/static/extensions/types/index.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="./ConduitChild.d.ts" />
+/// <reference path="./utils.d.ts" />

--- a/static/extensions/types/index.d.ts
+++ b/static/extensions/types/index.d.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /// <reference path="../../../src/link.d.ts" />
 
 /// <reference path="./ConduitChild.d.ts" />

--- a/static/extensions/types/index.d.ts
+++ b/static/extensions/types/index.d.ts
@@ -1,2 +1,4 @@
+/// <reference path="../../../src/link.d.ts" />
+
 /// <reference path="./ConduitChild.d.ts" />
 /// <reference path="./utils.d.ts" />

--- a/static/extensions/types/utils.d.ts
+++ b/static/extensions/types/utils.d.ts
@@ -821,4 +821,116 @@ declare global {
   }
   const LISTENERS: unique symbol
   const ONCE_MAP: unique symbol
+
+  interface TabAttachedEvent {
+    /** The native tab object in the window to which the tab is being attached. This may be a different object than was used to represent the tab in the old window. */
+    tab: NativeTab
+
+    /** The ID of the tab being attached. */
+    tabId: number
+
+    /** The ID of the window to which the tab is being attached. */
+    newWindowId: number
+
+    /** The position of the tab in the tab list of the new window. */
+    newPosition: number
+  }
+
+  interface TabDetachedEvent {
+    /** The native tab object in the window from which the tab is being detached. This may be a different object than will be used to represent the tab in the new window. */
+    tab: NativeTab
+
+    /** The native tab object in the window to which the tab will be attached, and is adopting the contents of this tab. This may be a different object than the tab in the previous window. */
+    adoptedBy: NativeTab
+
+    /** The ID of the tab being detached. */
+    tabId: number
+
+    /** The ID of the window from which the tab is being detached. */
+    oldWindowId: number
+
+    /** The position of the tab in the tab list of the window from which it is being detached. */
+    oldPosition: number
+  }
+
+  interface TabCreatedEvent {
+    /** The native tab object for the tab which is being created. */
+    tab: NativeTab
+  }
+
+  interface TabRemovedEvent {
+    /** The native tab object for the tab which is being removed. */
+    tab: NativeTab
+
+    /** The ID of the tab being removed. */
+    tabId: number
+
+    /** The ID of the window from which the tab is being removed. */
+    windowId: number
+
+    /** True if the tab is being removed because the window is closing. */
+    isWindowClosing: boolean
+  }
+
+  interface BrowserData {
+    /** The numeric ID of the tab that a <browser> belongs to, or -1 if it does not belong to a tab. */
+    tabId: number
+
+    /** The numeric ID of the browser window that a <browser> belongs to, or -1 if it does not belong to a browser window. */
+    windowId: number
+  }
+
+  type NativeTab = any
+  type XULElement = any
+
+  /**
+   * A platform-independent base class for the platform-specific TabTracker
+   * classes, which track the opening and closing of tabs, and manage the mapping
+   * of them between numeric IDs and native tab objects.
+   */
+  abstract class TabTrackerBase extends EventEmitter {
+    protected initialized: boolean
+
+    on(...args: any[]): void
+
+    /**
+     * Called to initialize the tab tracking listeners the first time that an
+     * event listener is added.
+     */
+    protected abstract init(): void
+
+    /**
+     * Returns the numeric ID for the given native tab.
+     *
+     * @param nativeTab The native tab for which to return an ID.
+     * @returns The tab's numeric ID.
+     */
+    abstract getId(nativeTab: NativeTab): number
+
+    /**
+     * Returns the native tab with the given numeric ID.
+     *
+     * @param tabId The numeric ID of the tab to return.
+     * @param default_ The value to return if no tab exists with the given ID.
+     * @returns The native tab.
+     * @throws If no tab exists with the given ID and a default return value is not provided.
+     */
+    abstract getTab(tabId: number, default_?: any): NativeTab
+
+    /**
+     * Returns basic information about the tab and window that the given browser
+     * belongs to.
+     *
+     * @param browser The XUL browser element for which to return data.
+     * @returns Browser data.
+     */
+    abstract getBrowserData(browser: XULElement): BrowserData
+
+    /**
+     * Returns the native tab object for the active tab in the
+     * most-recently focused window, or null if no live tabs currently
+     * exist.
+     */
+    abstract get activeTab(): NativeTab | null
+  }
 }

--- a/static/extensions/types/utils.d.ts
+++ b/static/extensions/types/utils.d.ts
@@ -1,0 +1,824 @@
+/* eslint-disable @typescript-eslint/ban-types */
+/// <reference types="gecko-types" />
+import { ConduitAddress } from 'resource://gre/modules/ConduitsParent.sys.mjs'
+import { Extension } from 'resource://gre/modules/Extension.sys.mjs'
+import { SchemaRoot } from 'resource://gre/modules/Schemas.sys.mjs'
+
+import { PointConduit } from './ConduitChild'
+
+declare global {
+  type SavedFrame = unknown
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  function getConsole(): any
+  function runSafeSyncWithoutClone(f: any, ...args: any[]): any
+  function instanceOf(value: any, type: any): boolean
+  /**
+   * Convert any of several different representations of a date/time to a Date object.
+   * Accepts several formats:
+   * a Date object, an ISO8601 string, or a number of milliseconds since the epoch as
+   * either a number or a string.
+   *
+   * @param {Date|string|number} date
+   *      The date to convert.
+   * @returns {Date}
+   *      A Date object
+   */
+  function normalizeTime(date: Date | string | number): Date
+  function withHandlingUserInput(window: any, callable: any): any
+  /**
+   * Defines a lazy getter for the given property on the given object. The
+   * first time the property is accessed, the return value of the getter
+   * is defined on the current `this` object with the given property name.
+   * Importantly, this means that a lazy getter defined on an object
+   * prototype will be invoked separately for each object instance that
+   * it's accessed on.
+   *
+   * @param {object} object
+   *        The prototype object on which to define the getter.
+   * @param {string | symbol} prop
+   *        The property name for which to define the getter.
+   * @param {Function} getter
+   *        The function to call in order to generate the final property
+   *        value.
+   */
+  function defineLazyGetter(
+    object: object,
+    prop: string | symbol,
+    getter: Function,
+  ): void
+  function checkLoadURI(uri: any, principal: any, options: any): boolean
+  function checkLoadURL(url: any, principal: any, options: any): boolean
+  function makeWidgetId(id: any): any
+  function LocaleData(data: any): void
+  class LocaleData {
+    constructor(data: any)
+    defaultLocale: any
+    selectedLocale: any
+    locales: any
+    warnedMissingKeys: Set<any>
+    messages: any
+    serialize(): {
+      defaultLocale: any
+      selectedLocale: any
+      messages: any
+      locales: any
+    }
+    BUILTIN: string
+    has(locale: any): any
+    localizeMessage(message: any, substitutions?: any[], options?: {}): any
+    localize(str: any, locale?: any): any
+    addLocale(locale: any, messages: any, extension: any): Map<any, any>
+    get acceptLanguages(): any
+    get uiLocale(): any
+  }
+  const ExtensionCommon: any
+  /**
+   * A sentinel class to indicate that an array of values should be
+   * treated as an array when used as a promise resolution value, but as a
+   * spread expression (...args) when passed to a callback.
+   */
+  class SpreadArgs extends Array<any> {
+    constructor(args: any)
+  }
+  /**
+   * Like SpreadArgs, but also indicates that the array values already
+   * belong to the target compartment, and should not be cloned before
+   * being passed.
+   *
+   * The `unwrappedValues` property contains an Array object which belongs
+   * to the target compartment, and contains the same unwrapped values
+   * passed the NoCloneSpreadArgs constructor.
+   */
+  class NoCloneSpreadArgs {
+    constructor(args: any)
+    unwrappedValues: any;
+    [Symbol.iterator](): any
+  }
+  class EventEmitter {
+    /**
+     * Checks whether there is some listener for the given event.
+     *
+     * @param {string} event
+     *       The name of the event to listen for.
+     * @returns {boolean}
+     */
+    has(event: string): boolean
+    /**
+     * Adds the given function as a listener for the given event.
+     *
+     * The listener function may optionally return a Promise which
+     * resolves when it has completed all operations which event
+     * dispatchers may need to block on.
+     *
+     * @param {string} event
+     *       The name of the event to listen for.
+     * @param {function(string, ...any)} listener
+     *        The listener to call when events are emitted.
+     */
+    on(event: string, listener: (arg0: string, ...args: any[]) => any): void
+    /**
+     * Removes the given function as a listener for the given event.
+     *
+     * @param {string} event
+     *       The name of the event to stop listening for.
+     * @param {function(string, ...any)} listener
+     *        The listener function to remove.
+     */
+    off(event: string, listener: (arg0: string, ...args: any[]) => any): void
+    /**
+     * Adds the given function as a listener for the given event once.
+     *
+     * @param {string} event
+     *       The name of the event to listen for.
+     * @param {function(string, ...any)} listener
+     *        The listener to call when events are emitted.
+     */
+    once(event: string, listener: (arg0: string, ...args: any[]) => any): void
+    /**
+     * Triggers all listeners for the given event. If any listeners return
+     * a value, returns a promise which resolves when all returned
+     * promises have resolved. Otherwise, returns undefined.
+     *
+     * @param {string} event
+     *       The name of the event to emit.
+     * @param {any} args
+     *        Arbitrary arguments to pass to the listener functions, after
+     *        the event name.
+     * @returns {Promise?}
+     */
+    emit(event: string, ...args: any): Promise<any> | null
+    [LISTENERS]: Map<any, any>;
+    [ONCE_MAP]: WeakMap<object, any>
+  }
+  /**
+   * Base class for WebExtension APIs.  Each API creates a new class
+   * that inherits from this class, the derived class is instantiated
+   * once for each extension that uses the API.
+   */
+  class ExtensionAPI extends EventEmitter {
+    constructor(extension: any)
+    extension: any
+    destroy(): void
+    onManifestEntry(entry: any): void
+    getAPI(context: any): void
+  }
+  /**
+   * Subclass to add APIs commonly used with persistent events.
+   * If a namespace uses events, it should use this subclass.
+   *
+   * this.apiNamespace = class extends ExtensionAPIPersistent {};
+   */
+  class ExtensionAPIPersistent extends ExtensionAPI {
+    /**
+     * Check for event entry.
+     *
+     * @param {string} event The event name e.g. onStateChanged
+     * @returns {boolean}
+     */
+    hasEventRegistrar(event: string): boolean
+    /**
+     * Get the event registration fuction
+     *
+     * @param {string} event The event name e.g. onStateChanged
+     * @returns {Function} register is used to start the listener
+     *                     register returns an object containing
+     *                     a convert and unregister function.
+     */
+    getEventRegistrar(event: string): Function
+    /**
+     * Used when instantiating an EventManager instance to register the listener.
+     *
+     * @param {object}      options         Options used for event registration
+     * @param {BaseContext} options.context Extension Context passed when creating an EventManager instance.
+     * @param {string}      options.event   The eAPI vent name.
+     * @param {Function}    options.fire    The function passed to the listener to fire the event.
+     * @param {Array<any>}  params          An optional array of parameters received along with the
+     *                                      addListener request.
+     * @returns {Function}                  The unregister function used in the EventManager.
+     */
+    registerEventListener(
+      options: {
+        context: BaseContext
+        event: string
+        fire: Function
+      },
+      params: Array<any>,
+    ): Function
+    /**
+     * Used to prime a listener for when the background script is not running.
+     *
+     * @param {string} event The event name e.g. onStateChanged or captiveURL.onChange.
+     * @param {Function} fire The function passed to the listener to fire the event.
+     * @param {Array} params Params passed to the event listener.
+     * @param {boolean} isInStartup unused here but passed for subclass use.
+     * @returns {object} the unregister and convert functions used in the EventManager.
+     */
+    primeListener(
+      event: string,
+      fire: Function,
+      params: any[],
+      isInStartup: boolean,
+    ): object
+  }
+  /**
+   * This class contains the information we have about an individual
+   * extension.  It is never instantiated directly, instead subclasses
+   * for each type of process extend this class and add members that are
+   * relevant for that process.
+   *
+   * @abstract
+   */
+  class BaseContext {
+    constructor(envType: any, extension: any)
+    envType: any
+    onClose: Set<any>
+    checkedLastError: boolean
+    _lastError: any
+    contextId: any
+    unloaded: boolean
+    extension: any
+    manifestVersion: any
+    jsonSandbox: any
+    active: boolean
+    incognito: any
+    messageManager: any
+    contentWindow: any
+    innerWindowID: number
+    cloneScopeError: any
+    cloneScopePromise: any
+    get isProxyContextParent(): boolean
+    get Error(): any
+    get Promise(): any
+    get privateBrowsingAllowed(): any
+    get isBackgroundContext(): boolean
+    /**
+     * Whether the extension context is using the WebIDL bindings for the
+     * WebExtensions APIs.
+     * To be overridden in subclasses (e.g. WorkerContextChild) and to be
+     * optionally used in ExtensionAPI classes to customize the behavior of the
+     * API when the calls to the extension API are originated from the WebIDL
+     * bindings.
+     */
+    get useWebIDLBindings(): boolean
+    canAccessWindow(window: any): any
+    canAccessContainer(userContextId: any): any
+    /**
+     * Opens a conduit linked to this context, populating related address fields.
+     * Only available in child contexts with an associated contentWindow.
+     *
+     * @param {object} subject
+     * @param {ConduitAddress} address
+     * @returns {PointConduit}
+     */
+    openConduit(subject: object, address: ConduitAddress): PointConduit
+    setContentWindow(contentWindow: any): void
+    logActivity(type: any, name: any, data: any): void
+    get cloneScope(): void
+    get principal(): void
+    runSafe(callback: any, ...args: any[]): any
+    runSafeWithoutClone(callback: any, ...args: any[]): any
+    applySafe(callback: any, args: any, caller: any): any
+    applySafeWithoutClone(callback: any, args: any, caller: any): any
+    checkLoadURL(url: any, options?: {}): boolean
+    /**
+     * Safely call JSON.stringify() on an object that comes from an
+     * extension.
+     *
+     * @param {Array<any>} args Arguments for JSON.stringify()
+     * @returns {string} The stringified representation of obj
+     */
+    jsonStringify(...args: Array<any>): string
+    callOnClose(obj: any): void
+    forgetOnClose(obj: any): void
+    set lastError(val: any)
+    get lastError(): any
+    /**
+     * Normalizes the given error object for use by the target scope. If
+     * the target is an error object which belongs to that scope, it is
+     * returned as-is. If it is an ordinary object with a `message`
+     * property, it is converted into an error belonging to the target
+     * scope. If it is an Error object which does *not* belong to the
+     * clone scope, it is reported, and converted to an unexpected
+     * exception error.
+     *
+     * @param {Error|object} error
+     * @param {SavedFrame?} [caller]
+     * @returns {Error}
+     */
+    normalizeError(error: Error | object, caller?: SavedFrame): Error
+    /**
+     * Sets the value of `.lastError` to `error`, calls the given
+     * callback, and reports an error if the value has not been checked
+     * when the callback returns.
+     *
+     * @param {object} error An object with a `message` property. May
+     *     optionally be an `Error` object belonging to the target scope.
+     * @param {SavedFrame?} caller
+     *        The optional caller frame which triggered this callback, to be used
+     *        in error reporting.
+     * @param {Function} callback The callback to call.
+     * @returns {*} The return value of callback.
+     */
+    withLastError(error: object, caller: SavedFrame, callback: Function): any
+    /**
+     * Captures the most recent stack frame which belongs to the extension.
+     *
+     * @returns {SavedFrame?}
+     */
+    getCaller(): SavedFrame
+    /**
+     * Wraps the given promise so it can be safely returned to extension
+     * code in this context.
+     *
+     * If `callback` is provided, however, it is used as a completion
+     * function for the promise, and no promise is returned. In this case,
+     * the callback is called when the promise resolves or rejects. In the
+     * latter case, `lastError` is set to the rejection value, and the
+     * callback function must check `browser.runtime.lastError` or
+     * `extension.runtime.lastError` in order to prevent it being reported
+     * to the console.
+     *
+     * @param {Promise} promise The promise with which to wrap the
+     *     callback. May resolve to a `SpreadArgs` instance, in which case
+     *     each element will be used as a separate argument.
+     *
+     *     Unless the promise object belongs to the cloneScope global, its
+     *     resolution value is cloned into cloneScope prior to calling the
+     *     `callback` function or resolving the wrapped promise.
+     *
+     * @param {Function} [callback] The callback function to wrap
+     *
+     * @returns {Promise|undefined} If callback is null, a promise object
+     *     belonging to the target scope. Otherwise, undefined.
+     */
+    wrapPromise(
+      promise: Promise<any>,
+      callback?: Function,
+    ): Promise<any> | undefined
+    unload(): void
+    /**
+     * A simple proxy for unload(), for use with callOnClose().
+     */
+    close(): void
+  }
+  /**
+   * An object that runs the implementation of a schema API. Instantiations of
+   * this interfaces are used by Schemas.jsm.
+   *
+   * @interface
+   */
+  class SchemaAPIInterface {
+    /**
+     * Calls this as a function that returns its return value.
+     *
+     * @abstract
+     * @param {Array} args The parameters for the function.
+     * @returns {*} The return value of the invoked function.
+     */
+    callFunction(args: any[]): any
+    /**
+     * Calls this as a function and ignores its return value.
+     *
+     * @abstract
+     * @param {Array} args The parameters for the function.
+     */
+    callFunctionNoReturn(args: any[]): void
+    /**
+     * Calls this as a function that completes asynchronously.
+     *
+     * @abstract
+     * @param {Array} args The parameters for the function.
+     * @param {function(*)} [callback] The callback to be called when the function
+     *     completes.
+     * @param {boolean} [requireUserInput=false] If true, the function should
+     *                  fail if the browser is not currently handling user input.
+     * @returns {Promise|undefined} Must be void if `callback` is set, and a
+     *     promise otherwise. The promise is resolved when the function completes.
+     */
+    callAsyncFunction(
+      args: any[],
+      callback?: (arg0: any) => any,
+      requireUserInput?: boolean,
+    ): Promise<any> | undefined
+    /**
+     * Retrieves the value of this as a property.
+     *
+     * @abstract
+     * @returns {*} The value of the property.
+     */
+    getProperty(): any
+    /**
+     * Assigns the value to this as property.
+     *
+     * @abstract
+     * @param {string} value The new value of the property.
+     */
+    setProperty(value: string): void
+    /**
+     * Registers a `listener` to this as an event.
+     *
+     * @abstract
+     * @param {Function} listener The callback to be called when the event fires.
+     * @param {Array} args Extra parameters for EventManager.addListener.
+     * @see EventManager.addListener
+     */
+    addListener(listener: Function, args: any[]): void
+    /**
+     * Checks whether `listener` is listening to this as an event.
+     *
+     * @abstract
+     * @param {Function} listener The event listener.
+     * @returns {boolean} Whether `listener` is registered with this as an event.
+     * @see EventManager.hasListener
+     */
+    hasListener(listener: Function): boolean
+    /**
+     * Unregisters `listener` from this as an event.
+     *
+     * @abstract
+     * @param {Function} listener The event listener.
+     * @see EventManager.removeListener
+     */
+    removeListener(listener: Function): void
+    /**
+     * Revokes the implementation object, and prevents any further method
+     * calls from having external effects.
+     *
+     * @abstract
+     */
+    revoke(): void
+  }
+  /**
+   * An object that runs a locally implemented API.
+   */
+  class LocalAPIImplementation extends SchemaAPIInterface {
+    /**
+     * Constructs an implementation of the `name` method or property of `pathObj`.
+     *
+     * @param {object} pathObj The object containing the member with name `name`.
+     * @param {string} name The name of the implemented member.
+     * @param {BaseContext} context The context in which the schema is injected.
+     */
+    constructor(pathObj: object, name: string, context: BaseContext)
+    pathObj: object
+    name: string
+    context: BaseContext
+    callFunction(args: any): any
+    callFunctionNoReturn(args: any): void
+    callAsyncFunction(
+      args: any,
+      callback: any,
+      requireUserInput: any,
+    ): Promise<any>
+    setProperty(value: any): void
+    addListener(listener: any, args: any): void
+    hasListener(listener: any): any
+    removeListener(listener: any): void
+  }
+  /**
+   * Manages loading and accessing a set of APIs for a specific extension
+   * context.
+   *
+   * @param {BaseContext} context
+   *        The context to manage APIs for.
+   * @param {SchemaAPIManager} apiManager
+   *        The API manager holding the APIs to manage.
+   * @param {object} root
+   *        The root object into which APIs will be injected.
+   */
+  class CanOfAPIs {
+    constructor(context: any, apiManager: any, root: any)
+    context: any
+    scopeName: any
+    apiManager: any
+    root: any
+    apiPaths: Map<any, any>
+    apis: Map<any, any>
+    /**
+     * Synchronously loads and initializes an ExtensionAPI instance.
+     *
+     * @param {string} name
+     *        The name of the API to load.
+     */
+    loadAPI(name: string): void
+    /**
+     * Asynchronously loads and initializes an ExtensionAPI instance.
+     *
+     * @param {string} name
+     *        The name of the API to load.
+     */
+    asyncLoadAPI(name: string): Promise<void>
+    /**
+     * Finds the API at the given path from the root object, and
+     * synchronously loads the API that implements it if it has not
+     * already been loaded.
+     *
+     * @param {string} path
+     *        The "."-separated path to find.
+     * @returns {*}
+     */
+    findAPIPath(path: string): any
+    /**
+     * Finds the API at the given path from the root object, and
+     * asynchronously loads the API that implements it if it has not
+     * already been loaded.
+     *
+     * @param {string} path
+     *        The "."-separated path to find.
+     * @returns {Promise<*>}
+     */
+    asyncFindAPIPath(path: string): Promise<any>
+  }
+  /**
+   * @class APIModule
+   * @abstract
+   *
+   * @property {string} url
+   *       The URL of the script which contains the module's
+   *       implementation. This script must define a global property
+   *       matching the modules name, which must be a class constructor
+   *       which inherits from {@link ExtensionAPI}.
+   *
+   * @property {string} schema
+   *       The URL of the JSON schema which describes the module's API.
+   *
+   * @property {Array<string>} scopes
+   *       The list of scope names into which the API may be loaded.
+   *
+   * @property {Array<string>} manifest
+   *       The list of top-level manifest properties which will trigger
+   *       the module to be loaded, and its `onManifestEntry` method to be
+   *       called.
+   *
+   * @property {Array<string>} events
+   *       The list events which will trigger the module to be loaded, and
+   *       its appropriate event handler method to be called. Currently
+   *       only accepts "startup".
+   *
+   * @property {Array<string>} permissions
+   *       An optional list of permissions, any of which must be present
+   *       in order for the module to load.
+   *
+   * @property {Array<Array<string>>} paths
+   *       A list of paths from the root API object which, when accessed,
+   *       will cause the API module to be instantiated and injected.
+   */
+  /**
+   * This object loads the ext-*.js scripts that define the extension API.
+   *
+   * This class instance is shared with the scripts that it loads, so that the
+   * ext-*.js scripts and the instantiator can communicate with each other.
+   */
+  class SchemaAPIManager extends EventEmitter {
+    /**
+     * @param {string} processType
+     *     "main" - The main, one and only chrome browser process.
+     *     "addon" - An addon process.
+     *     "content" - A content process.
+     *     "devtools" - A devtools process.
+     * @param {SchemaRoot} schema
+     */
+    constructor(processType: string, schema: SchemaRoot)
+    processType: string
+    global: object
+    schema: any
+    modules: Map<any, any>
+    modulePaths: {
+      children: Map<any, any>
+      modules: Set<any>
+    }
+    manifestKeys: Map<any, any>
+    eventModules: any
+    settingsModules: Set<any>
+    _modulesJSONLoaded: boolean
+    schemaURLs: Map<any, any>
+    apis: any
+    _scriptScopes: any[]
+    onStartup(extension: any): Promise<any[]>
+    loadModuleJSON(urls: any): Promise<any>
+    initModuleJSON(blobs: any): any
+    initModuleData(moduleData: any): void
+    /**
+     * Registers a set of ExtensionAPI modules to be lazily loaded and
+     * managed by this manager.
+     *
+     * @param {object} obj
+     *        An object containing property for eacy API module to be
+     *        registered. Each value should be an object implementing the
+     *        APIModule interface.
+     */
+    registerModules(obj: object): void
+    /**
+     * Emits an `onManifestEntry` event for the top-level manifest entry
+     * on all relevant {@link ExtensionAPI} instances for the given
+     * extension.
+     *
+     * The API modules will be synchronously loaded if they have not been
+     * loaded already.
+     *
+     * @param {Extension} extension
+     *        The extension for which to emit the events.
+     * @param {string} entry
+     *        The name of the top-level manifest entry.
+     *
+     * @returns {*}
+     */
+    emitManifestEntry(extension: Extension, entry: string): any
+    /**
+     * Emits an `onManifestEntry` event for the top-level manifest entry
+     * on all relevant {@link ExtensionAPI} instances for the given
+     * extension.
+     *
+     * The API modules will be asynchronously loaded if they have not been
+     * loaded already.
+     *
+     * @param {Extension} extension
+     *        The extension for which to emit the events.
+     * @param {string} entry
+     *        The name of the top-level manifest entry.
+     *
+     * @returns {Promise<*>}
+     */
+    asyncEmitManifestEntry(extension: Extension, entry: string): Promise<any>
+    /**
+     * Returns the {@link ExtensionAPI} instance for the given API module,
+     * for the given extension, in the given scope, synchronously loading
+     * and instantiating it if necessary.
+     *
+     * @param {string} name
+     *        The name of the API module to load.
+     * @param {Extension} extension
+     *        The extension for which to load the API.
+     * @param {string} [scope = null]
+     *        The scope type for which to retrieve the API, or null if not
+     *        being retrieved for a particular scope.
+     *
+     * @returns {ExtensionAPI?}
+     */
+    getAPI(
+      name: string,
+      extension: Extension,
+      scope?: string,
+    ): ExtensionAPI | null
+    /**
+     * Returns the {@link ExtensionAPI} instance for the given API module,
+     * for the given extension, in the given scope, asynchronously loading
+     * and instantiating it if necessary.
+     *
+     * @param {string} name
+     *        The name of the API module to load.
+     * @param {Extension} extension
+     *        The extension for which to load the API.
+     * @param {string} [scope = null]
+     *        The scope type for which to retrieve the API, or null if not
+     *        being retrieved for a particular scope.
+     *
+     * @returns {Promise<ExtensionAPI>?}
+     */
+    asyncGetAPI(
+      name: string,
+      extension: Extension,
+      scope?: string,
+    ): Promise<ExtensionAPI> | null
+    /**
+     * Synchronously loads an API module, if not already loaded, and
+     * returns its ExtensionAPI constructor.
+     *
+     * @param {string} name
+     *        The name of the module to load.
+     */
+    loadModule(name: string): unknown
+    /**
+     * aSynchronously loads an API module, if not already loaded, and
+     * returns its ExtensionAPI constructor.
+     *
+     * @param {string} name
+     *        The name of the module to load.
+     *
+     * @returns {Promise<class>}
+     */
+    asyncLoadModule(name: string): Promise<any>
+    asyncLoadSettingsModules(): Promise<any[]>
+    getModule(name: any): any
+    /**
+     * Checks whether the given API module may be loaded for the given
+     * extension, in the given scope.
+     *
+     * @param {string} name
+     *        The name of the API module to check.
+     * @param {Extension} extension
+     *        The extension for which to check the API.
+     * @param {string} [scope = null]
+     *        The scope type for which to check the API, or null if not
+     *        being checked for a particular scope.
+     *
+     * @returns {boolean}
+     *        Whether the module may be loaded.
+     */
+    _checkGetAPI(name: string, extension: Extension, scope?: string): boolean
+    _checkLoadModule(module: any, name: any): void
+    /**
+     * Create a global object that is used as the shared global for all ext-*.js
+     * scripts that are loaded via `loadScript`.
+     *
+     * @returns {object} A sandbox that is used as the global by `loadScript`.
+     */
+    _createExtGlobal(): object
+    initGlobal(): void
+    /**
+     * Load an ext-*.js script. The script runs in its own scope, if it wishes to
+     * share state with another script it can assign to the `global` variable. If
+     * it wishes to communicate with this API manager, use `extensions`.
+     *
+     * @param {string} scriptUrl The URL of the ext-*.js script.
+     */
+    loadScript(scriptUrl: string): void
+  }
+  /**
+   * This is a generic class for managing event listeners.
+   *
+   * @example
+   * new EventManager({
+   *   context,
+   *   name: "api.subAPI",
+   *   register:  fire => {
+   *     let listener = (...) => {
+   *       // Fire any listeners registered with addListener.
+   *       fire.async(arg1, arg2);
+   *     };
+   *     // Register the listener.
+   *     SomehowRegisterListener(listener);
+   *     return () => {
+   *       // Return a way to unregister the listener.
+   *       SomehowUnregisterListener(listener);
+   *     };
+   *   }
+   * }).api()
+   *
+   * The result is an object with addListener, removeListener, and
+   * hasListener methods. `context` is an add-on scope (either an
+   * ExtensionContext in the chrome process or ExtensionContext in a
+   * content process).
+   */
+  class EventManager {
+    static _initPersistentListeners(extension: any): boolean
+    static _writePersistentListeners(extension: any): void
+    static primeListeners(extension: any, isInStartup?: boolean): void
+    /**
+     * This is called as a result of background script startup-finished and shutdown.
+     *
+     * After startup, it removes any remaining primed listeners.  These exist if the
+     * listener was not renewed during startup.  In this case the persisted listener
+     * data is also removed.
+     *
+     * During shutdown, care should be taken to set clearPersistent to false.
+     * persisted listener data should NOT be cleared during shutdown.
+     *
+     * @param {Extension} extension
+     * @param {boolean} clearPersistent whether the persisted listener data should be cleared.
+     */
+    static clearPrimedListeners(
+      extension: Extension,
+      clearPersistent?: boolean,
+    ): void
+    static savePersistentListener(
+      extension: any,
+      module: any,
+      event: any,
+      args?: any[],
+    ): any[]
+    static clearPersistentListener(
+      extension: any,
+      module: any,
+      event: any,
+      key?: any,
+      primeId?: any,
+    ): void
+    constructor(params: any)
+    context: any
+    module: any
+    event: any
+    name: any
+    register: any
+    inputHandling: any
+    resetIdleOnEvent: any
+    canPersistEvents: any
+    unregister: Map<any, any>
+    remove: Map<any, any>
+    addListener(callback: any, ...args: any[]): void
+    removeListener(callback: any, clearPersistentListener?: boolean): void
+    hasListener(callback: any): boolean
+    revoke(): void
+    close(): void
+    api(): {
+      [x: number]: () => void
+      addListener: (...args: any[]) => void
+      removeListener: (...args: any[]) => void
+      hasListener: (...args: any[]) => boolean
+      setUserInput: any
+    }
+  }
+  const LISTENERS: unique symbol
+  const ONCE_MAP: unique symbol
+}

--- a/static/extensions/types/utils.d.ts
+++ b/static/extensions/types/utils.d.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* eslint-disable @typescript-eslint/ban-types */
 /// <reference types="gecko-types" />
 import { ConduitAddress } from 'resource://gre/modules/ConduitsParent.sys.mjs'

--- a/static/localization/en-US/branding/brand.ftl
+++ b/static/localization/en-US/branding/brand.ftl
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/static/localization/en-US/browser/appExtensionFields.ftl
+++ b/static/localization/en-US/browser/appExtensionFields.ftl
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+## Theme names and descriptions used in the Themes panel in about:addons
+
+# "Auto" is short for automatic. It can be localized without limitations.
+extension-default-theme-name-auto=System theme — auto
+extension-default-theme-description=Follow the operating system setting for buttons, menus, and windows.
+
+extension-firefox-compact-light-name=Light
+extension-firefox-compact-light-description=A theme with a light color scheme.
+
+extension-firefox-compact-dark-name=Dark
+extension-firefox-compact-dark-description=A theme with a dark color scheme.
+
+extension-firefox-alpenglow-name=Firefox Alpenglow
+extension-firefox-alpenglow-description=Use a colorful appearance for buttons, menus, and windows.
+
+## Colorway Themes
+## These themes are variants of a colorway. The colorway is specified in the
+## $colorway-name variable.
+## Variables
+##   $colorway-name (String) The name of a colorway (e.g. Graffiti, Elemental).
+
+extension-colorways-soft-name={ $colorway-name } — Soft
+extension-colorways-balanced-name={ $colorway-name } — Balanced
+# "Bold" is used in the sense of bravery or courage, not in the sense of
+# emphasized text.
+extension-colorways-bold-name={ $colorway-name } — Bold

--- a/static/localization/en-US/browser/components/mozSupportLink.ftl
+++ b/static/localization/en-US/browser/components/mozSupportLink.ftl
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/static/localization/link.json
+++ b/static/localization/link.json
@@ -1,6 +1,5 @@
 [
   "en-US/branding/brand.ftl",
-  "en-US/branding/brand.properties",
   "en-US/browser/components/mozSupportLink.ftl",
   "en-US/browser/appExtensionFields.ftl"
 ]

--- a/static/localization/link.json
+++ b/static/localization/link.json
@@ -1,0 +1,6 @@
+[
+  "en-US/branding/brand.ftl",
+  "en-US/branding/brand.properties",
+  "en-US/browser/components/mozSupportLink.ftl",
+  "en-US/browser/appExtensionFields.ftl"
+]

--- a/static/modules/mitt.sys.mjs
+++ b/static/modules/mitt.sys.mjs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /*
  * MIT License
  *

--- a/static/modules/sessionstore/SessionStore.sys.mjs
+++ b/static/modules/sessionstore/SessionStore.sys.mjs
@@ -1,0 +1,3 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */


### PR DESCRIPTION
I am very slightly burnt out on dealing with extension apis for the moment (not great considering the backlog). 

![image](https://github.com/pulse-browser/experiment/assets/23250792/54cd07f3-7124-40e2-9240-2e51320f54f1)

What has been implemented:
- The entire [manifest key](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action)
- The [`onClicked`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked) event - Note that this is not perfectly compatible.
- [`show`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/show) and [`hide`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/hide)

What will be implemented in a future pull request:
 - `isShown`
 - `setTitle` and `getTitle`
 - `setIcon`
 - `setPopup` and `getPopup`
 - `openPopup`

Some extension api examples can be found [in the test-extensions repo](https://github.com/pulse-browser/test-extensions).