### PR TITLE
🚧 Provide a TabBase and TabManagerBase implementation

### DIFF
--- a/apps/extensions/lib/parent/ext-browser.js
+++ b/apps/extensions/lib/parent/ext-browser.js
@@ -192,6 +192,14 @@ class TabManager extends TabManagerBase {
   wrapTab(nativeTab) {
     return new Tab(this.extension, nativeTab, nativeTab.view.browserId || -1)
   }
+
+  /**
+   * @param {NativeTab} nativeTab
+   * @public
+   */
+  publicWrapTab(nativeTab) {
+    return this.wrapTab(nativeTab)
+  }
 }
 
 extensions.on('startup', (type, extension) => {

--- a/apps/extensions/lib/parent/ext-browser.js
+++ b/apps/extensions/lib/parent/ext-browser.js
@@ -89,3 +89,111 @@ class TabTracker extends TabTrackerBase {
 /** @global */
 let tabTracker = new TabTracker()
 Object.assign(global, { tabTracker })
+
+class Tab extends TabBase {
+  get _favIconUrl() {
+    return this.nativeTab.view.iconUrl
+  }
+
+  get lastAccessed() {
+    return undefined
+  }
+  get audible() {
+    return undefined
+  }
+  get autoDiscardable() {
+    return false
+  }
+  get browser() {
+    return this.nativeTab.view.browser
+  }
+  get cookieStoreId() {
+    return undefined
+  }
+  get discarded() {
+    return undefined
+  }
+  get height() {
+    return this.nativeTab.view.browser.clientHeight
+  }
+  get hidden() {
+    return false
+  }
+  get index() {
+    const window = this.window
+    return (
+      window
+        ?.windowTabs()
+        .findIndex(
+          (tab) => tab.view.browserId == this.nativeTab.view.browserId,
+        ) || -1
+    )
+  }
+  get mutedInfo() {
+    return undefined
+  }
+  get sharingState() {
+    return undefined
+  }
+  get pinned() {
+    return false
+  }
+  get active() {
+    const window = this.window
+    return window?.activeTabId() == this.nativeTab.view.windowBrowserId
+  }
+  get highlighted() {
+    const window = this.window
+    return (
+      window
+        ?.selectedTabIds()
+        .some((tab) => tab == this.nativeTab.view.windowBrowserId) ?? false
+    )
+  }
+  get status() {
+    return this.nativeTab.view.websiteState
+  }
+  get width() {
+    return this.browser.clientWidth
+  }
+  get window() {
+    return lazy.WindowTracker.getWindowWithBrowser(this.nativeTab.view.browser)
+      ?.window
+  }
+  get windowId() {
+    return this.window?.windowId || -1
+  }
+  get attention() {
+    return false
+  }
+  get isArticle() {
+    return false
+  }
+  get isInReaderMode() {
+    return false
+  }
+  get successorTabId() {
+    return undefined
+  }
+}
+
+class TabManager extends TabManagerBase {
+  canAccessTab(_nativeTab) {
+    throw new Error('Method ')
+  }
+  get(tabId) {
+    const results = lazy.WindowTracker.getWindowWithBrowserId(tabId)
+    if (!results) return null
+    return this.wrapTab(results.tab)
+  }
+  /**
+   * @param {NativeTab} nativeTab
+   */
+  wrapTab(nativeTab) {
+    return new Tab(this.extension, nativeTab, nativeTab.view.browserId || -1)
+  }
+}
+
+extensions.on('startup', (type, extension) => {
+  defineLazyGetter(extension, 'tabManager', () => new TabManager(extension))
+})

--- a/apps/extensions/lib/parent/ext-browser.js
+++ b/apps/extensions/lib/parent/ext-browser.js
@@ -21,7 +21,7 @@ const lazy = lazyESModuleGetters({
 class TabTracker extends TabTrackerBase {
   get activeTab() {
     const window = lazy.WindowTracker.getActiveWindow()
-    return window?.activeTab()
+    return window?.activeTab() || null
   }
 
   init() {
@@ -48,28 +48,6 @@ class TabTracker extends TabTrackerBase {
     }
 
     return tab
-  }
-
-  /**
-   * @param {import('resource://gre/modules/Extension.sys.mjs').Extension} extension
-   * @param {import('@browser/tabs').WindowTab} tab
-   * @param {Window} window
-   *
-   * @returns {tabs__tabs.Tab}
-   */
-  serializeTab(extension, tab, window) {
-    // TODO: Active tab & host permissions
-    const hasTabPermission = extension.hasPermission('tabs')
-
-    return {
-      id: tab.view.browserId,
-      index: window.windowTabs().findIndex((wTab) => wTab === tab),
-      active: window.activeTab() === tab,
-      highlighted: false, // TODO
-      title: (hasTabPermission && tab.view.title) || undefined,
-      url: (hasTabPermission && tab.view.uri.asciiSpec) || undefined,
-      windowId: window.windowId,
-    }
   }
 
   /**

--- a/apps/extensions/lib/parent/ext-browserAction.js
+++ b/apps/extensions/lib/parent/ext-browserAction.js
@@ -13,7 +13,6 @@ this.browserAction = class extends ExtensionAPIPersistent {
 
   async onManifestEntry() {
     const { extension } = this
-    /** @type {browser_action__manifest.WebExtensionManifest__extended['browser_action']} */
     const options = extension.manifest.browser_action
 
     if (!options) {
@@ -67,25 +66,16 @@ this.browserAction = class extends ExtensionAPIPersistent {
      *        running extension context.
      */
     onClicked({ fire }) {
-      const { extension } = this
+      const /** @type {Extension} */ extension = this.extension
 
       /**
        * @param {import("resource://app/modules/EBrowserActions.sys.mjs").IBrowserActionEvents['click']} clickInfo
        */
       const callback = async (_name, clickInfo) => {
         if (fire.wakeup) await fire.wakeup()
-        const { tab, window } = lazy.WindowTracker.getWindowWithBrowserId(
-          clickInfo.tabId,
-        ) || { tab: null, window: null }
 
-        if (!tab || !window) {
-          return fire.sync(null, clickInfo.clickData)
-        }
-
-        fire.sync(
-          tabTracker.serializeTab(extension, tab, window),
-          clickInfo.clickData,
-        )
+        const tab = extension.tabManager.get(clickInfo.tabId)
+        fire.sync(tab.convert(), clickInfo.clickData)
       }
 
       this.on('click', callback)

--- a/apps/extensions/lib/parent/ext-tabs.js
+++ b/apps/extensions/lib/parent/ext-tabs.js
@@ -7,62 +7,6 @@
 /// <reference path="./ext-browser.js"  />
 /// <reference types="@browser/link" />
 
-/**
- * @param {tabs__tabs.QueryInfo} queryInfo
- * @returns {[import("@browser/tabs").WindowTab, Window][]}
- */
-function query(queryInfo) {
-  const windows = [...lazy.WindowTracker.registeredWindows.entries()]
-
-  const urlMatchSet =
-    (queryInfo.url &&
-      (Array.isArray(queryInfo.url)
-        ? new MatchPatternSet(queryInfo.url)
-        : new MatchPatternSet([queryInfo.url]))) ||
-    null
-
-  return windows.flatMap(([windowId, window]) => {
-    const tabs = window.windowTabs()
-    const activeTab = window.activeTab()
-
-    return tabs
-      .filter((tab) => {
-        const active =
-          queryInfo.active !== null
-            ? queryInfo.active
-              ? tab === activeTab
-              : tab !== activeTab
-            : true
-        const title = queryInfo.title
-          ? queryInfo.title === tab.view.title
-          : true
-        const url =
-          urlMatchSet === null
-            ? true
-            : urlMatchSet.matches(tab.view.uri.asciiSpec)
-        const window =
-          queryInfo.windowId === null ? true : queryInfo.windowId === windowId
-
-        return active && title && url && window
-      })
-      .map(
-        /** @returns {[import("@browser/tabs").WindowTab, Window]} */ (tab) => [
-          tab,
-          window,
-        ],
-      )
-  })
-}
-
-const serialize =
-  (extension) =>
-  /**
-   * @param {[import("@browser/tabs").WindowTab, Window]} in
-   * @returns {tabs__tabs.Tab}
-   */
-  ([tab, window]) =>
-    tabTracker.serializeTab(extension, tab, window)
-
 this.tabs = class extends ExtensionAPIPersistent {
   PERSISTENT_EVENTS = {}
 

--- a/apps/extensions/lib/types/utils.d.ts
+++ b/apps/extensions/lib/types/utils.d.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /// <reference types="gecko-types" />
 import { ConduitAddress } from 'resource://gre/modules/ConduitsParent.sys.mjs'
-import { Extension } from 'resource://gre/modules/Extension.sys.mjs'
+import { Extension as ToolkitExtension } from 'resource://gre/modules/Extension.sys.mjs'
 import { SchemaRoot } from 'resource://gre/modules/Schemas.sys.mjs'
 
 import { PointConduit } from './ConduitChild'
@@ -14,6 +14,12 @@ declare global {
   type SavedFrame = unknown
   type NativeTab = import('@browser/tabs').WindowTab
   type XULElement = Element
+
+  interface Extension extends ToolkitExtension {
+    tabManager: TabManagerBase
+    manifest: Omit<browser._manifest.WebExtensionManifest, 'browser_action'> &
+      browser_action__manifest.WebExtensionManifest__extended
+  }
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   function getConsole(): any
@@ -1532,6 +1538,15 @@ declare global {
 
     matches(queryInfo: QueryInfo): boolean
 
+    /**
+     * Converts this tab object to a JSON-compatible object containing the values
+     * of its properties which the extension is permitted to access, in the format
+     * required to be returned by WebExtension APIs.
+     *
+     * @param [fallbackTabSize]
+     *        A geometry data if the lazy geometry data for this tab hasn't been
+     *        initialized yet.
+     */
     convert(fallbackTabSize?: any): any
 
     queryContent(message: string, options: Options): Promise<any>[]

--- a/apps/extensions/lib/types/utils.d.ts
+++ b/apps/extensions/lib/types/utils.d.ts
@@ -16,7 +16,7 @@ declare global {
   type XULElement = Element
 
   interface Extension extends ToolkitExtension {
-    tabManager: TabManagerBase
+    tabManager: TabManagerBase & { publicWrapTab(nativeTab: NativeTab): Tab }
     manifest: Omit<browser._manifest.WebExtensionManifest, 'browser_action'> &
       browser_action__manifest.WebExtensionManifest__extended
   }
@@ -174,7 +174,7 @@ declare global {
     extension: Extension
     destroy(): void
     onManifestEntry(entry: any): void
-    getAPI(context: any): void
+    getAPI(context: BaseContext): unknown
   }
   /**
    * Subclass to add APIs commonly used with persistent events.
@@ -250,7 +250,7 @@ declare global {
     _lastError: any
     contextId: any
     unloaded: boolean
-    extension: any
+    extension: Extension
     manifestVersion: any
     jsonSandbox: any
     active: boolean
@@ -1214,12 +1214,11 @@ declare global {
      *
      * @param queryInfo An object containing properties on which to filter.
      * @param context The extension context for which the matching is being performed.
-     * @returns Iterator<TabBase>
      */
     query(
       queryInfo?: object | null,
       context?: BaseContext | null,
-    ): Iterator<TabBase>
+    ): Iterable<TabBase>
 
     /**
      * Returns a TabBase wrapper for the tab with the given ID.
@@ -1390,7 +1389,7 @@ declare global {
      * @readonly
      * @abstract
      */
-    abstract readonly browser: XULElement
+    abstract readonly browser: XULBrowserElement
 
     /**
      * @property browsingContext

--- a/libs/link/types/schemaTypes/index.d.ts
+++ b/libs/link/types/schemaTypes/index.d.ts
@@ -1,3 +1,3 @@
-// @not-mpl
+// @not-mpl 
 /// <reference path="./browser_action.d.ts" />
 /// <reference path="./tabs.d.ts" />


### PR DESCRIPTION
Mozilla provides shared code for implementing tab apis that I was avoiding using. However, because they expect it to exist, I have moved over to using it and all the problems that will cause. Here is the main changes:
- Created `Tab` and `TabManager` extending `TabBase` and `TabManagerBase`
- Moved code in `ext-browserActions` and `ext-tabs` to use the new apis
- Cleaned up the dead apis.